### PR TITLE
role-based access rules for admin, editor, and viewer roles

### DIFF
--- a/docs/roles-access.md
+++ b/docs/roles-access.md
@@ -1,131 +1,119 @@
-# NoteNest – Roles & Access Control (RBAC)
+# NoteNest – Role-Based Access Control (RBAC) Proposal
 
-This document explains how **roles and permissions** work in NoteNest.
-It helps contributors understand **who can do what** inside the application.
-
----
-
-## What is Role-Based Access Control (RBAC)?
-
-RBAC is a system where:
-- Users are assigned **roles**
-- Roles define **permissions**
-- Permissions control actions
-
-This is a common pattern used in real-world applications.
+## 1. Overview
+This document proposes the Role-Based Access Control (RBAC) system for NoteNest. The goal is to define clear permissions for **Admin**, **Editor**, and **Viewer** roles within a **Workspace** context. This ensures security, clarity, and effective collaboration.
 
 ---
 
-## Roles in NoteNest
+## 2. Role Definitions
 
-NoteNest supports the following roles within a workspace:
+Roles are assigned **per workspace**. A user can be an Admin in one workspace and a Viewer in another.
 
-### 🟢 Admin
-**Description:** Workspace owner or manager
+### 🟢 **Admin**
+**Description:** The manager or owner of the workspace. Has full control over content and users.
+**Primary Goal:** Manage the team and maintain workspace usage.
 
-**Permissions:**
-- Create, edit, and delete notes
-- Manage users in the workspace
-- Assign or change roles
-- Access all workspace content
+### 🟡 **Editor**
+**Description:** A content creator and collaborator.
+**Primary Goal:** Contribute knowledge, write notes, and update documentation.
+**Limitations:** Cannot manage other users or dangerous workspace settings.
 
----
-
-### 🟡 Editor
-**Description:** Contributor who creates and edits content
-
-**Permissions:**
-- Create new notes
-- Edit existing notes
-- View all accessible notes
-
-**Restrictions:**
-- Cannot manage users
-- Cannot change roles
+### 🔵 **Viewer**
+**Description:** A read-only consumer of information.
+**Primary Goal:** Read, search, and learn from the knowledge base.
+**Limitations:** Strictly read-only access.
 
 ---
 
-### 🔵 Viewer
-**Description:** Read-only user
+## 3. Permissions Matrix
 
-**Permissions:**
-- View notes
-- Search notes
+The following table defines the exact capabilities of each role.
 
-**Restrictions:**
-- Cannot create or edit notes
-- Cannot manage users
+| Category | Action | 🟢 Admin | 🟡 Editor | 🔵 Viewer |
+| :--- | :--- | :---: | :---: | :---: |
+| **Content** | **View Notes** | ✅ | ✅ | ✅ |
+| | **Create Notes** | ✅ | ✅ | ❌ |
+| | **Edit Notes** | ✅ | ✅ | ❌ |
+| | **Delete Notes** | ✅ | ✅ (Own) / ❌ (Others) | ❌ |
+| | **Restore Deleted Notes** | ✅ | ❌ | ❌ |
+| **Users** | **Invite Members** | ✅ | ❌ | ❌ |
+| | **Remove Members** | ✅ | ❌ | ❌ |
+| | **Change Member Roles** | ✅ | ❌ | ❌ |
+| **Workspace** | **Update Settings** | ✅ | ❌ | ❌ |
+| | **Delete Workspace** | ✅ | ❌ | ❌ |
 
----
-
-## Role Assignment
-
-- Roles are assigned **per workspace**
-- A user can have different roles in different workspaces
-- Role checks are enforced by the backend
-
-Example:
-- User A → Admin in Workspace X
-- User A → Viewer in Workspace Y
+> **Note on Deletion:** Editors can delete notes they created (Authorship), but only Admins can delete notes created by others. This prevents accidental data loss.
 
 ---
 
-## How Roles Affect the UI
+## 4. Use Cases
 
-The frontend should:
-- Show edit options only to Admins and Editors
-- Hide or disable actions for Viewers
-- Display role-based navigation options
+### Scenario A: Team Onboarding
+1. **Admin** creates a new Workspace "Engineering Team".
+2. **Admin** invites Alice (Engineering Manager) as an **Admin**.
+3. **Admin** invites Bob (Developer) as an **Editor**.
+4. **Bob** logs in, sees "Engineering Team", and creates a "Setup Guide".
 
-The backend is the **final authority** on permissions.
+### Scenario B: Collaboration
+1. **Bob (Editor)** drafts a note "API Documentation".
+2. **Charlie (Viewer)** reads the note to understand the API.
+3. **Charlie** notices a typo but **cannot edit** it. He messages Bob.
+4. **Bob** updates the note.
 
----
-
-## Backend Enforcement (Important)
-
-Even if the UI hides a button:
-- The backend must still validate permissions
-
-This prevents:
-- Unauthorized access
-- Security loopholes
-
----
-
-## Role-Based Contribution Areas
-
-Contributors can help by:
-- Implementing role-check middleware
-- Improving permission logic
-- Updating UI based on roles
-- Writing documentation for RBAC
-- Adding tests for access control
+### Scenario C: Moderation
+1. **Bob (Editor)** accidentally posts sensitive keys in a note.
+2. **Alice (Admin)** sees this and immediately **deletes the note**.
+3. **Bob** cannot undo this action if permanent, but **Alice** can restore it if it was a soft delete.
 
 ---
 
-## Why RBAC Matters for OSQ
+## 5. Edge Cases & Constraints
 
-RBAC teaches:
-- Security fundamentals
-- Real-world backend logic
-- Clean separation of responsibilities
+### 🛑 The "Last Admin" Problem
+**Rule:** A Workspace MUST have at least one Admin.
+- If an **Admin** tries to leave the workspace or downgrade their role to Editor/Viewer, the system must check if there is another Admin.
+- If they are the **only** Admin, the action is **blocked**. They must promote someone else first.
 
-It is a **high-value learning area**.
+### 🔄 Role Updates
+- If a user's role is updated (e.g., Editor → Viewer) while they are active, the change should take effect **immediately** on their next action (backend validation) or after a page refresh.
 
----
-
-## What Roles Do NOT Control
-
-Roles do NOT:
-- Control authentication (login)
-- Control database structure directly
-- Replace backend validation
+### 🚫 Self-Deletion
+- A user can remove themselves from a workspace, UNLESS they are the last Admin (see "Last Admin" problem).
 
 ---
 
-## Final Note
+## 6. Implementation Guidelines
 
-Roles and permissions are central to NoteNest.
-Clear implementation and documentation of RBAC is more important than advanced features.
+### Database Schema (Conceptual)
+In the `WorkspaceMember` collection/table:
+```json
+{
+  "userId": "user_123",
+  "workspaceId": "ws_456",
+  "role": "admin" // enum: ['admin', 'editor', 'viewer']
+}
+```
 
-Build it clearly, securely, and collaboratively 🚀
+### Backend Middleware
+Middleware should enforce permissions on every protected route.
+```typescript
+// Example Middleware Usage
+app.post("/notes", requireRole("editor"), createNoteHandler);
+app.delete("/notes/:id", requireRole("admin"), deleteNoteHandler);
+```
+
+### Frontend UI
+- **Hide Buttons:** If the user is a Viewer, hide "Edit" and "Delete" buttons.
+- **Disable Inputs:** deeply make forms read-only.
+- **Visual Indicators:** Show a "Read Only" badge for Viewers.
+
+---
+
+## 7. Future Considerations
+- **"Owner" Role:** Distinct from Admin, capable of billing management (if paid features exist).
+- **Custom Roles:** Allowing granular permission selection (e.g., "Can Create but NOT Delete").
+- **Private Notes:** Notes allowed only for specific users within a workspace.
+
+---
+**Status:** 📝 Draft Proposal
+**Authors:** Contributors


### PR DESCRIPTION
Task Completed: Defined permissions and rules for Admin, Editor, and Viewer roles.

File Created: 
docs/roles-access.md

Key Contributions:

Clear Role Definitions:
Admin: Full control over workspace, users, and content.
Editor: Can create and edit notes but cannot manage users.
Viewer: Read-only access to specific notes.

Permissions Matrix:
Designed a table explicitly mapping actions (Create, Edit, Delete, Invite) to each role.

Safety & Edge Cases:
"Last Admin" Protection: Specific rule preventing a workspace from having zero admins.
Content Safety: Editors can only delete their own notes, protecting team knowledge.

Technical Implementation Guide:
Provided a JSON schema for WorkspaceMember.
Outlined middleware logic (requireRole("admin")) for backend enforcement.