### PR TITLE
Implement Empty, Loading & Error States Across Core UI #23

### DIFF
--- a/frontend/app/dashboard/dashboard.tsx
+++ b/frontend/app/dashboard/dashboard.tsx
@@ -1,13 +1,39 @@
 "use client";
 
-import { useState } from "react";
+import Link from "next/link";
+import { useState, useEffect } from "react";
 import Sidebar from "@/components/Sidebar";
 import Header from "@/components/Header";
 import EmptyState from "@/components/EmptyState";
+import ErrorState from "@/components/ErrorState";
+import { SkeletonList } from "@/components/Skeleton";
 
 export default function DashboardPage() {
-  const [recentNotes] = useState<Array<{ id: number; title: string; updatedAt: string }>>([]);
-  const [recentActivity] = useState<Array<{ id: number; action: string; timestamp: string }>>([]);
+  const [recentNotes, setRecentNotes] = useState<Array<{ id: number; title: string; updatedAt: string }>>([]);
+  const [recentActivity, setRecentActivity] = useState<Array<{ id: number; action: string; timestamp: string }>>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Simulate loading dashboard data (no backend)
+    const timer = setTimeout(() => {
+      setRecentNotes([]);
+      setRecentActivity([]);
+      setLoadError(null);
+      setIsLoading(false);
+    }, 800);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const retryLoad = () => {
+    setLoadError(null);
+    setIsLoading(true);
+    setTimeout(() => {
+      setRecentNotes([]);
+      setRecentActivity([]);
+      setIsLoading(false);
+    }, 600);
+  };
 
   return (
     <div className="flex">
@@ -32,6 +58,21 @@ export default function DashboardPage() {
             This is your NoteNest dashboard. Get started by creating your first note.
           </p>
 
+          {loadError && (
+            <ErrorState
+              title="Couldn't load dashboard"
+              message={loadError}
+              variant="error"
+              onDismiss={() => setLoadError(null)}
+              action={
+                <button type="button" onClick={retryLoad} className="btn-primary" style={{ fontSize: "var(--font-size-sm)", padding: "var(--space-sm) var(--space-md)" }}>
+                  Try again
+                </button>
+              }
+              className="mb-6"
+            />
+          )}
+
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {/* Recent Notes Section */}
             <div>
@@ -41,14 +82,26 @@ export default function DashboardPage() {
               >
                 Recent Notes
               </h3>
-              {recentNotes.length === 0 ? (
-                <div 
-                  className="bg-white rounded-lg border border-gray-200 p-6"
+              {isLoading ? (
+                <div
+                  className="animate-fade-in bg-white rounded-lg border p-6"
                   style={{
-                    boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.03)'
+                    borderColor: "var(--color-border-light)",
+                    boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.03)",
+                  }}
+                >
+                  <SkeletonList count={3} variant="list-item" />
+                </div>
+              ) : recentNotes.length === 0 ? (
+                <div
+                  className="state-content-enter bg-white rounded-lg border p-6 card-elevate"
+                  style={{
+                    borderColor: "var(--color-border-light)",
+                    boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.03)",
                   }}
                 >
                   <EmptyState
+                    size="compact"
                     icon={
                       <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -56,11 +109,15 @@ export default function DashboardPage() {
                     }
                     title="No recent notes"
                     description="Notes you create or edit will appear here."
-                    className="!min-h-0 !py-4"
+                    secondaryAction={
+                      <Link href="/notes" className="link-nav" style={{ fontSize: "var(--font-size-sm)" }}>
+                        View all notes →
+                      </Link>
+                    }
                   />
                 </div>
               ) : (
-                <ul className="space-y-2">
+                <ul className="state-content-enter space-y-2">
                   {recentNotes.map((note) => (
                     <li
                       key={note.id}
@@ -86,14 +143,26 @@ export default function DashboardPage() {
               >
                 Recent Activity
               </h3>
-              {recentActivity.length === 0 ? (
-                <div 
-                  className="bg-white rounded-lg border border-gray-200 p-6"
+              {isLoading ? (
+                <div
+                  className="animate-fade-in bg-white rounded-lg border p-6"
                   style={{
-                    boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.03)'
+                    borderColor: "var(--color-border-light)",
+                    boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.03)",
+                  }}
+                >
+                  <SkeletonList count={3} variant="list-item" />
+                </div>
+              ) : recentActivity.length === 0 ? (
+                <div
+                  className="state-content-enter bg-white rounded-lg border p-6 card-elevate"
+                  style={{
+                    borderColor: "var(--color-border-light)",
+                    boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.03)",
                   }}
                 >
                   <EmptyState
+                    size="compact"
                     icon={
                       <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -101,11 +170,10 @@ export default function DashboardPage() {
                     }
                     title="No recent activity"
                     description="Your activity will be displayed here as you use NoteNest."
-                    className="!min-h-0 !py-4"
                   />
                 </div>
               ) : (
-                <ul className="space-y-2">
+                <ul className="state-content-enter space-y-2">
                   {recentActivity.map((activity) => (
                     <li
                       key={activity.id}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -764,6 +764,11 @@ article:not([tabindex]):not([onclick]):hover {
   min-height: 300px;
 }
 
+.empty-state.empty-state--compact {
+  min-height: 0;
+  padding: var(--space-md) 0;
+}
+
 .empty-state-content {
   max-width: 400px;
   width: 100%;
@@ -809,8 +814,36 @@ article:not([tabindex]):not([onclick]):hover {
   margin-top: var(--space-sm);
 }
 
+.empty-state-content--compact .empty-state-icon {
+  width: 48px;
+  height: 48px;
+}
+
+.empty-state-content--compact .empty-state-title {
+  font-size: var(--font-size-lg);
+}
+
+.empty-state-content--large {
+  max-width: 480px;
+}
+
+.empty-state-content--large .empty-state-icon {
+  width: 80px;
+  height: 80px;
+}
+
+.empty-state-content--large .empty-state-title {
+  font-size: var(--font-size-2xl);
+}
+
+/* Content enter (when transitioning from loading to content) */
+.state-content-enter {
+  animation: fade-in-up 0.4s ease-out forwards;
+}
+
 /* Error State */
 .error-state {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/app/login/login.tsx
+++ b/frontend/app/login/login.tsx
@@ -84,6 +84,17 @@ export default function LoginPage() {
             message={errors.general}
             variant="error"
             className="mb-4"
+            onDismiss={() => setErrors((prev) => ({ ...prev, general: undefined }))}
+            action={
+              <button
+                type="button"
+                onClick={() => setErrors((prev) => ({ ...prev, general: undefined }))}
+                className="btn-primary"
+                style={{ fontSize: "var(--font-size-sm)", padding: "var(--space-sm) var(--space-md)" }}
+              >
+                Try again
+              </button>
+            }
           />
         )}
 

--- a/frontend/app/notes/notes.tsx
+++ b/frontend/app/notes/notes.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Sidebar from "@/components/Sidebar";
 import EmptyState from "@/components/EmptyState";
+import ErrorState from "@/components/ErrorState";
+import { SkeletonList } from "@/components/Skeleton";
 
 interface Note {
   id: number;
@@ -10,18 +12,45 @@ interface Note {
 }
 
 export default function NotesPage() {
-  const [notes, setNotes] = useState<Note[]>([
-    { id: 1, title: "Project Overview" },
-    { id: 2, title: "Meeting Notes" },
-  ]);
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Simulate loading notes (no backend)
+    const timer = setTimeout(() => {
+      setNotes([
+        { id: 1, title: "Project Overview" },
+        { id: 2, title: "Meeting Notes" },
+      ]);
+      setLoadError(null);
+      setIsLoading(false);
+    }, 600);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const retryLoad = () => {
+    setLoadError(null);
+    setIsLoading(true);
+    setTimeout(() => {
+      setNotes([
+        { id: 1, title: "Project Overview" },
+        { id: 2, title: "Meeting Notes" },
+      ]);
+      setIsLoading(false);
+    }, 600);
+  };
 
   const handleCreateNote = () => {
+    setActionError(null);
     // In a real app, this would open a modal or navigate to create page
     console.log("Create note clicked");
   };
 
   const handleDeleteNote = (id: number) => {
-    setNotes(notes.filter(note => note.id !== id));
+    setActionError(null);
+    setNotes(notes.filter((note) => note.id !== id));
   };
 
   return (
@@ -30,22 +59,64 @@ export default function NotesPage() {
 
       <main className="flex-1 p-6">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-bold">Notes</h1>
-          <button 
+          <h1 className="text-2xl font-bold" style={{ color: "var(--color-text-primary)" }}>Notes</h1>
+          <button
             onClick={handleCreateNote}
             className="btn-primary"
             style={{
-              fontSize: 'var(--font-size-sm)',
-              padding: 'var(--space-sm) var(--space-md)',
-              minHeight: '36px'
+              fontSize: "var(--font-size-sm)",
+              padding: "var(--space-sm) var(--space-md)",
+              minHeight: "36px",
             }}
           >
             Create Note
           </button>
         </div>
 
-        {notes.length === 0 ? (
+        {loadError && (
+          <ErrorState
+            title="Couldn't load notes"
+            message={loadError}
+            variant="error"
+            onDismiss={() => setLoadError(null)}
+            action={
+              <button type="button" onClick={retryLoad} className="btn-primary" style={{ fontSize: "var(--font-size-sm)", padding: "var(--space-sm) var(--space-md)" }}>
+                Try again
+              </button>
+            }
+            className="mb-6"
+          />
+        )}
+
+        {actionError && (
+          <ErrorState
+            title="Something went wrong"
+            message={actionError}
+            variant="warning"
+            onDismiss={() => setActionError(null)}
+            action={
+              <button type="button" onClick={() => setActionError(null)} className="btn-secondary" style={{ fontSize: "var(--font-size-sm)", padding: "var(--space-sm) var(--space-md)" }}>
+                Dismiss
+              </button>
+            }
+            className="mb-4"
+          />
+        )}
+
+        {isLoading ? (
+          <div
+            className="animate-fade-in bg-white rounded-lg border p-6"
+            style={{
+              borderColor: "var(--color-border-light)",
+              boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.05), 0 1px 2px 0 rgba(0, 0, 0, 0.03)",
+            }}
+          >
+            <SkeletonList count={4} variant="list-item" />
+          </div>
+        ) : notes.length === 0 ? (
+          <div className="state-content-enter">
           <EmptyState
+            size="large"
             icon={
               <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -54,26 +125,32 @@ export default function NotesPage() {
             title="No notes yet"
             description="Get started by creating your first note. Organize your thoughts, ideas, and knowledge in one place."
             action={
-              <button 
+              <button
                 onClick={handleCreateNote}
                 className="btn-primary"
                 style={{
-                  fontSize: 'var(--font-size-base)',
-                  padding: 'var(--space-sm) var(--space-lg)'
+                  fontSize: "var(--font-size-base)",
+                  padding: "var(--space-sm) var(--space-lg)",
                 }}
               >
                 Create Your First Note
               </button>
             }
           />
+          </div>
         ) : (
-          <ul className="space-y-2">
-            {notes.map((note) => (
+          <ul className="state-content-enter space-y-2">
+            {notes.map((note, index) => (
               <li
                 key={note.id}
-                className="bg-white p-4 rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow duration-200 flex items-center justify-between group"
+                className="animate-fade-in-up bg-white p-4 rounded-lg shadow-sm border flex items-center justify-between group hover-lift"
+                style={{
+                  borderColor: "var(--color-border-light)",
+                  animationDelay: `${index * 50}ms`,
+                  animationFillMode: "backwards",
+                }}
               >
-                <span className="text-gray-900 font-medium">{note.title}</span>
+                <span className="font-medium" style={{ color: "var(--color-text-primary)" }}>{note.title}</span>
                 <button
                   onClick={() => handleDeleteNote(note.id)}
                   className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 text-red-500 hover:text-red-700 p-1"

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -839,26 +839,18 @@ export default function Home() {
             <div className={`w-full max-w-lg text-center lg:text-left transition-all duration-1000 delay-300 ${mounted ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-4'}`}>
               <div className="inline-block mb-6">
                 <span 
-                  className="inline-flex items-center text-sm font-bold uppercase tracking-wider px-5 py-2.5 rounded-full transition-all duration-300 hover:scale-105"
+                  className="inline-flex items-center rounded-lg transition-all duration-200 hover:opacity-90 border uppercase tracking-wide"
                   style={{ 
-                    background: 'linear-gradient(135deg, rgba(59, 130, 246, 0.12) 0%, rgba(139, 92, 246, 0.12) 100%)',
+                    background: 'linear-gradient(135deg, rgba(59, 130, 246, 0.08) 0%, rgba(139, 92, 246, 0.08) 100%)',
                     color: 'var(--color-info)',
                     fontSize: 'var(--font-size-xs)',
-                    letterSpacing: '0.12em',
-                    border: '1.5px solid rgba(59, 130, 246, 0.25)',
-                    boxShadow: '0 2px 8px -2px rgba(59, 130, 246, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
-                    backdropFilter: 'blur(8px)',
-                    fontWeight: 'var(--font-weight-bold)'
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = 'linear-gradient(135deg, rgba(59, 130, 246, 0.18) 0%, rgba(139, 92, 246, 0.18) 100%)';
-                    e.currentTarget.style.borderColor = 'rgba(59, 130, 246, 0.4)';
-                    e.currentTarget.style.boxShadow = '0 4px 12px -2px rgba(59, 130, 246, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.15)';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = 'linear-gradient(135deg, rgba(59, 130, 246, 0.12) 0%, rgba(139, 92, 246, 0.12) 100%)';
-                    e.currentTarget.style.borderColor = 'rgba(59, 130, 246, 0.25)';
-                    e.currentTarget.style.boxShadow = '0 2px 8px -2px rgba(59, 130, 246, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.1)';
+                    letterSpacing: '0.1em',
+                    borderColor: 'rgba(59, 130, 246, 0.2)',
+                    fontWeight: 'var(--font-weight-semibold)',
+                    boxShadow: '0 1px 2px rgba(59, 130, 246, 0.06)',
+                    padding: 'var(--space-sm) var(--space-lg)',
+                    minHeight: '2.25rem',
+                    lineHeight: 1.4
                   }}
                 >
                   Built for Everyone

--- a/frontend/components/EmptyState.tsx
+++ b/frontend/components/EmptyState.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React from "react";
 
 interface EmptyStateProps {
   icon?: React.ReactNode;
   title: string;
   description?: string;
   action?: React.ReactNode;
+  /** Secondary action (e.g. link) below primary CTA */
+  secondaryAction?: React.ReactNode;
   className?: string;
+  /** Visual size: compact (cards), default, or large (full page) */
+  size?: "compact" | "default" | "large";
 }
 
 export default function EmptyState({
@@ -13,17 +17,31 @@ export default function EmptyState({
   title,
   description,
   action,
-  className = ''
+  secondaryAction,
+  className = "",
+  size = "default",
 }: EmptyStateProps) {
+  const sizeClass =
+    size === "compact"
+      ? "empty-state-content--compact"
+      : size === "large"
+        ? "empty-state-content--large"
+        : "";
+  const wrapperClass = size === "compact" ? "empty-state--compact" : "";
+
   return (
-    <div 
-      className={`empty-state ${className}`}
+    <div
+      className={`empty-state animate-fade-in-up ${wrapperClass} ${className}`}
       role="status"
       aria-live="polite"
     >
-      <div className="empty-state-content">
+      <div className={`empty-state-content ${sizeClass}`}>
         {icon && (
-          <div className="empty-state-icon" aria-hidden="true">
+          <div
+            className="empty-state-icon"
+            aria-hidden="true"
+            style={{ color: "var(--color-text-muted)" }}
+          >
             {icon}
           </div>
         )}
@@ -32,8 +50,14 @@ export default function EmptyState({
           <p className="empty-state-description">{description}</p>
         )}
         {action && (
-          <div className="empty-state-action">
-            {action}
+          <div className="empty-state-action">{action}</div>
+        )}
+        {secondaryAction && (
+          <div
+            className="empty-state-action mt-2"
+            style={{ marginTop: "var(--space-sm)" }}
+          >
+            {secondaryAction}
           </div>
         )}
       </div>

--- a/frontend/components/ErrorState.tsx
+++ b/frontend/components/ErrorState.tsx
@@ -1,53 +1,62 @@
-import React from 'react';
+import React from "react";
 
 interface ErrorStateProps {
   title?: string;
   message: string;
   action?: React.ReactNode;
   className?: string;
-  variant?: 'error' | 'warning' | 'info';
+  variant?: "error" | "warning" | "info";
+  /** Callback when dismiss (X) is clicked; if provided, shows dismiss button */
+  onDismiss?: () => void;
 }
 
 export default function ErrorState({
   title,
   message,
   action,
-  className = '',
-  variant = 'error'
+  className = "",
+  variant = "error",
+  onDismiss,
 }: ErrorStateProps) {
   return (
-    <div 
-      className={`error-state error-state-${variant} ${className}`}
+    <div
+      className={`error-state error-state-${variant} animate-scale-in relative ${className}`}
       role="alert"
       aria-live="assertive"
     >
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="error-state-dismiss btn-icon absolute top-3 right-3"
+          aria-label="Dismiss"
+        >
+          <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
       <div className="error-state-content">
         <div className="error-state-icon" aria-hidden="true">
-          {variant === 'error' && (
+          {variant === "error" && (
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           )}
-          {variant === 'warning' && (
+          {variant === "warning" && (
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
           )}
-          {variant === 'info' && (
+          {variant === "info" && (
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           )}
         </div>
-        {title && (
-          <h3 className="error-state-title">{title}</h3>
-        )}
+        {title && <h3 className="error-state-title">{title}</h3>}
         <p className="error-state-message">{message}</p>
-        {action && (
-          <div className="error-state-action">
-            {action}
-          </div>
-        )}
+        {action && <div className="error-state-action">{action}</div>}
       </div>
     </div>
   );

--- a/frontend/components/Loading.tsx
+++ b/frontend/components/Loading.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+interface LoadingProps {
+  message?: string;
+  className?: string;
+  /** Use for full-page or large content area loading */
+  fullPage?: boolean;
+  /** Spinner and layout size */
+  size?: "sm" | "md" | "lg";
+}
+
+const sizeConfig = {
+  sm: { spinner: "w-6 h-6", minHeight: "min-h-[120px]" },
+  md: { spinner: "w-10 h-10", minHeight: "min-h-[200px]" },
+  lg: { spinner: "w-12 h-12", minHeight: "min-h-[280px]" },
+};
+
+export default function Loading({
+  message,
+  className = "",
+  fullPage = false,
+  size = "md",
+}: LoadingProps) {
+  const config = sizeConfig[size];
+  const minHeightClass = fullPage ? config.minHeight : "py-8";
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center ${minHeightClass} animate-fade-in ${className}`}
+      role="status"
+      aria-live="polite"
+      aria-label={message ?? "Loading content"}
+    >
+      <div
+        className={`rounded-full border-2 border-t-transparent animate-spin ${config.spinner}`}
+        style={{
+          borderColor: "rgba(59, 130, 246, 0.25)",
+          borderTopColor: "var(--color-info)",
+        }}
+      />
+      {message && (
+        <p
+          className="mt-3 text-sm font-medium"
+          style={{
+            color: "var(--color-text-secondary)",
+            fontSize: "var(--font-size-sm)",
+          }}
+        >
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/Skeleton.tsx
+++ b/frontend/components/Skeleton.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+
+interface SkeletonProps {
+  className?: string;
+  /** Line variant: single line, or multiple lines (e.g. 3 for list item) */
+  lines?: number;
+  /** Card variant: rounded card placeholder */
+  variant?: "line" | "card" | "list-item" | "avatar";
+}
+
+export default function Skeleton({
+  className = "",
+  lines = 1,
+  variant = "line",
+}: SkeletonProps) {
+  const baseStyle: React.CSSProperties = {
+    backgroundColor: "var(--color-border-light)",
+    borderRadius: "var(--space-sm, 0.5rem)",
+  };
+
+  if (variant === "card") {
+    return (
+      <div
+        className={`loading-pulse w-full ${className}`}
+        style={{ ...baseStyle, minHeight: "6rem" }}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  if (variant === "avatar") {
+    return (
+      <div
+        className={`loading-pulse rounded-full shrink-0 ${className}`}
+        style={{ ...baseStyle, width: "2.5rem", height: "2.5rem" }}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  if (variant === "list-item") {
+    return (
+      <div
+        className={`flex flex-col gap-2 p-4 rounded-lg border ${className}`}
+        style={{
+          borderColor: "var(--color-border-light)",
+        }}
+        aria-hidden="true"
+      >
+        <div
+          className="loading-pulse h-4 rounded"
+          style={{ ...baseStyle, width: "70%", maxWidth: "12rem" }}
+        />
+        <div
+          className="loading-pulse h-3 rounded"
+          style={{ ...baseStyle, width: "40%", maxWidth: "8rem" }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`} aria-hidden="true">
+      {Array.from({ length: lines }).map((_, i) => (
+        <div
+          key={i}
+          className="loading-pulse h-4 rounded"
+          style={{
+            ...baseStyle,
+            width: i === lines - 1 && lines > 1 ? "60%" : "100%",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Skeleton for a list of items with staggered pulse delay */
+export function SkeletonList({
+  count = 3,
+  variant = "list-item",
+  className = "",
+}: {
+  count?: number;
+  variant?: "line" | "card" | "list-item";
+  className?: string;
+}) {
+  return (
+    <ul className={`space-y-2 ${className}`} aria-hidden="true">
+      {Array.from({ length: count }).map((_, i) => (
+        <li
+          key={i}
+          className="animate-fade-in"
+          style={{
+            animationDelay: `${i * 80}ms`,
+            animationFillMode: "backwards",
+          }}
+        >
+          <Skeleton variant={variant} />
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
# Implement Empty, Loading & Error States Across Core UI

Closes #23

## Summary

This PR adds **empty**, **loading**, and **error** states across the core NoteNest UI so the app handles real-world cases where data is missing, still loading, or fails to load. All changes are **frontend-only** (no backend or new pages), use the existing design system and CSS variables, and keep patterns consistent across Dashboard, Notes, and Login.

## Problem

The UI previously assumed data is always available and loads instantly. In real use, users may see:
- **Empty states** (e.g. no notes yet, no recent activity)
- **Loading states** (waiting for data)
- **Error conditions** (failed load or action)

Without clear feedback for these, the experience feels broken and unclear. This PR addresses that.

## What's Included

### New Components

| Component | Purpose |
|----------|---------|
| **`Loading`** | Reusable loading spinner with optional message; supports `sm` / `md` / `lg` and full-page layout. Uses design tokens and `aria-label` for accessibility. |
| **`Skeleton`** | Content placeholders with pulse animation. Variants: `line`, `card`, `list-item`, `avatar`. Uses `var(--color-border-light)` for theming. |
| **`SkeletonList`** | Renders multiple skeleton items with staggered fade-in for list loading. |

### Enhanced Components

| Component | Changes |
|----------|---------|
| **`EmptyState`** | Size variants (`compact`, `default`, `large`), entrance animation (`animate-fade-in-up`), optional `secondaryAction`, design-token icon color. |
| **`ErrorState`** | Entrance animation (`animate-scale-in`), optional `onDismiss` with close (X) button, `position: relative` for layout. |

### Page Updates

| Page | Loading | Empty | Error |
|------|---------|--------|------|
| **Dashboard** | Skeleton placeholders for Recent Notes and Recent Activity (simulated ~800ms load). | Existing empty states kept; compact size, “View all notes” link on Recent Notes, `state-content-enter` animation. | Error banner with “Try again” and dismiss (X); ready for real API `loadError`. |
| **Notes** | Skeleton list (4 items) on initial load (~600ms). | Full-page empty state with “No notes yet” and primary CTA; large size, content-enter animation. | Load error (retry + dismiss) and action error (dismiss); list items get staggered fade-in and hover lift. |
| **Login** | Submit button already shows loading state. | N/A | General error uses `ErrorState` with “Try again” and dismiss. |

### CSS (globals.css)

- **Empty state:** `.empty-state--compact`, `.empty-state-content--compact` / `--large` for padding and typography.
- **Content enter:** `.state-content-enter` (fade-in-up) when transitioning from loading to content.
- **Error state:** `position: relative` on `.error-state` for dismiss button placement.

### Other

- **Landing badge:** “Built for Everyone” pill updated to match site theme (blue–purple gradient, design tokens, padding).

## Files Changed

- **New:** `frontend/components/Skeleton.tsx`
- **Modified:** `frontend/components/Loading.tsx`, `frontend/components/EmptyState.tsx`, `frontend/components/ErrorState.tsx`
- **Modified:** `frontend/app/globals.css`
- **Modified:** `frontend/app/dashboard/dashboard.tsx`, `frontend/app/notes/notes.tsx`, `frontend/app/login/login.tsx`
- **Modified:** `frontend/app/page.tsx` (hero badge styling)

## How to Test

1. **Dashboard** (`/dashboard`)  
   - See skeleton placeholders, then empty states for Recent Notes and Recent Activity.  
   - Use “View all notes” from empty Recent Notes.  
   - (When wired to real API) trigger load error and use “Try again” and dismiss.

2. **Notes** (`/notes`)  
   - See skeleton list, then note list or empty state with “Create Your First Note”.  
   - Confirm list item hover and staggered entrance.

3. **Login** (`/login`)  
   - Submit with e.g. `error@example.com` to see error state; use “Try again” and dismiss.

4. **Reduced motion**  
   - Enable “Reduce motion” in OS; confirm animations are minimized (existing `prefers-reduced-motion` rules).

## Checklist

- [x] Loading indicators/skeletons on primary content areas (Dashboard, Notes)
- [x] Empty states with clear messaging and CTAs
- [x] Error states with retry and/or dismiss where appropriate
- [x] Consistent use of design system and CSS variables
- [x] No backend changes; frontend-only
- [x] No new pages
