### PR TITLE
Add Keyboard Shortcuts for Core Actions (Power-User UX) #25

### DIFF
--- a/frontend/app/dashboard/dashboard.tsx
+++ b/frontend/app/dashboard/dashboard.tsx
@@ -40,7 +40,7 @@ export default function DashboardPage() {
       <Sidebar />
 
       <div className="flex-1">
-        <Header />
+        <Header title="Dashboard" showSearch />
         <main className="p-6" style={{ maxWidth: '1200px', margin: '0 auto', width: '100%' }}>
           <h2 
             className="text-2xl font-bold mb-6"
@@ -204,6 +204,7 @@ export default function DashboardPage() {
               <a
                 href="/notes"
                 className="btn-primary"
+                data-shortcut="create-note"
                 style={{
                   fontSize: 'var(--font-size-base)',
                   padding: 'var(--space-sm) var(--space-lg)'

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import KeyboardShortcuts from "@/components/KeyboardShortcuts";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <KeyboardShortcuts />
         {children}
       </body>
     </html>

--- a/frontend/app/notes/notes.tsx
+++ b/frontend/app/notes/notes.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Sidebar from "@/components/Sidebar";
+import Header from "@/components/Header";
 import EmptyState from "@/components/EmptyState";
 import ErrorState from "@/components/ErrorState";
 import { SkeletonList } from "@/components/Skeleton";
@@ -57,12 +58,16 @@ export default function NotesPage() {
     <div className="flex">
       <Sidebar />
 
+      <div className="flex-1 flex flex-col">
+        <Header title="Notes" showSearch />
       <main className="flex-1 p-6">
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold" style={{ color: "var(--color-text-primary)" }}>Notes</h1>
           <button
+            type="button"
             onClick={handleCreateNote}
             className="btn-primary"
+            data-shortcut="create-note"
             style={{
               fontSize: "var(--font-size-sm)",
               padding: "var(--space-sm) var(--space-md)",
@@ -169,6 +174,7 @@ export default function NotesPage() {
           </ul>
         )}
       </main>
+      </div>
     </div>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -14,7 +14,16 @@ export default function Home() {
 
   useEffect(() => {
     setMounted(true);
-    
+  }, []);
+
+  // Close mobile menu when Escape is pressed (keyboard shortcut)
+  useEffect(() => {
+    const handleEsc = () => setMobileMenuOpen(false);
+    window.addEventListener("shortcut-esc", handleEsc);
+    return () => window.removeEventListener("shortcut-esc", handleEsc);
+  }, []);
+
+  useEffect(() => {
     // Handle scroll to show/hide scroll to top button and progress
     const handleScroll = () => {
       const scrollTop = window.scrollY;
@@ -300,26 +309,29 @@ export default function Home() {
               {/* Mobile Menu Button */}
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                className="btn-icon md:hidden flex-shrink-0 flex items-center justify-center"
+                className="btn-icon md:hidden flex-shrink-0 flex items-center justify-center transition-colors duration-200 hover:bg-blue-500/10 hover:text-[var(--color-info)]"
                 style={{ 
                   height: '44px',
                   width: '44px',
-                  flex: '0 0 auto'
+                  flex: '0 0 auto',
+                  color: 'var(--color-text-secondary)'
                 }}
                 aria-label="Toggle menu"
                 aria-expanded={mobileMenuOpen}
               >
               <svg 
-                className="w-6 h-6 transition-transform duration-300" 
+                className="w-6 h-6 transition-transform duration-300 shrink-0" 
                 style={{ transform: mobileMenuOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}
                 fill="none" 
                 stroke="currentColor" 
+                strokeWidth={2.25}
                 viewBox="0 0 24 24"
+                aria-hidden
               >
                 {mobileMenuOpen ? (
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                 ) : (
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M4 6h16M4 12h16M4 18h16" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
                 )}
               </svg>
               </button>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,7 +1,41 @@
-export default function Header() {
+"use client";
+
+interface HeaderProps {
+  title?: string;
+  /** When true, shows a search input that can be focused with / shortcut */
+  showSearch?: boolean;
+}
+
+export default function Header({ title = "Dashboard", showSearch = false }: HeaderProps) {
   return (
-    <header className="bg-white border-b p-4">
-      <h1 className="text-lg font-semibold">Dashboard</h1>
+    <header
+      className="flex items-center gap-4 border-b p-4"
+      style={{
+        background: "var(--color-background)",
+        borderColor: "var(--color-border-light)",
+      }}
+    >
+      <h1
+        className="text-lg font-semibold shrink-0"
+        style={{ color: "var(--color-text-primary)" }}
+      >
+        {title}
+      </h1>
+      {showSearch && (
+        <input
+          type="search"
+          data-shortcut="search"
+          placeholder="Search notes…"
+          aria-label="Search notes"
+          className="max-w-xs w-full rounded-lg border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1"
+          style={{
+            borderColor: "var(--color-border-light)",
+            color: "var(--color-text-primary)",
+            background: "var(--color-background)",
+            fontSize: "var(--font-size-sm)",
+          }}
+        />
+      )}
     </header>
   );
 }

--- a/frontend/components/KeyboardShortcuts.tsx
+++ b/frontend/components/KeyboardShortcuts.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+
+/**
+ * Renders nothing; registers global keyboard shortcuts when mounted.
+ * Include once in the app layout so shortcuts work across all pages.
+ */
+export default function KeyboardShortcuts() {
+  useKeyboardShortcuts();
+  return null;
+}

--- a/frontend/hooks/useKeyboardShortcuts.ts
+++ b/frontend/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Returns true if the event target is a focusable form control or editable region.
+ * Shortcuts should not fire when the user is typing.
+ */
+function isTypingElement(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  const tagName = target.tagName.toLowerCase();
+  const role = target.getAttribute?.("role") ?? "";
+  const editable = target.getAttribute?.("contenteditable") === "true";
+  if (editable) return true;
+  if (tagName === "input" || tagName === "textarea" || tagName === "select") return true;
+  if (role === "textbox" || role === "searchbox") return true;
+  return false;
+}
+
+/**
+ * Global keyboard shortcuts for NoteNest (power-user UX).
+ * - / → Focus search input (when available)
+ * - N → Focus or trigger create-note action (when available)
+ * - Esc → Close overlay / clear focus
+ *
+ * Shortcuts do not fire when focus is inside input, textarea, select, or contenteditable.
+ */
+export function useKeyboardShortcuts() {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isTypingElement(e.target)) return;
+
+      switch (e.key) {
+        case "/": {
+          e.preventDefault();
+          const search = document.querySelector<HTMLElement>('[data-shortcut="search"]');
+          if (search) {
+            search.focus();
+          }
+          break;
+        }
+        case "n":
+        case "N": {
+          // Don't trigger if Ctrl/Cmd is held (e.g. Ctrl+N is new window)
+          if (e.ctrlKey || e.metaKey) return;
+          e.preventDefault();
+          const createNote = document.querySelector<HTMLElement>('[data-shortcut="create-note"]');
+          if (createNote) {
+            if (createNote.tagName === "A") {
+              createNote.focus();
+            } else {
+              createNote.focus();
+              createNote.click();
+            }
+          }
+          break;
+        }
+        case "Escape": {
+          // Allow other handlers to run first; then blur and dispatch for overlays
+          window.dispatchEvent(new CustomEvent("shortcut-esc"));
+          (document.activeElement as HTMLElement)?.blur?.();
+          break;
+        }
+        default:
+          break;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, []);
+}


### PR DESCRIPTION
# Add Keyboard Shortcuts for Core Actions (Power-User UX)

Closes #25

## Summary

This PR adds a small set of **keyboard shortcuts** for core actions so power users, developers, and accessibility users can work faster without relying only on mouse or touch. Implementation is **frontend-only**, uses **client-side logic**, and does not change any backend or API. Shortcuts are non-intrusive, avoid browser conflicts, and do not fire when the user is typing in inputs or text areas.

## Problem

Previously, all interactions in NoteNest required mouse or touch. For users who rely on keyboard navigation, common actions were slower and less efficient. The app lacked shortcuts for frequently used actions.

## What's Included

### Shortcuts

| Shortcut | Action |
|----------|--------|
| **`/`** | Focus search input (when on Dashboard or Notes) |
| **`N`** | Focus or trigger "Create Note" (when on Dashboard or Notes) |
| **`Esc`** | Close overlay (e.g. mobile menu) or clear focus |

### Behavior

- **Do not fire in form fields:** Shortcuts are ignored when focus is in `input`, `textarea`, `select`, or `contenteditable`, so they never interfere with typing.
- **`N` respects modifier keys:** Ctrl+N / Cmd+N are left to the browser (e.g. new window); only plain `N` triggers the create-note action.
- **Discoverable:** Search and create-note targets use `data-shortcut` attributes; Esc dispatches a `shortcut-esc` custom event so any overlay (e.g. mobile menu) can close on Esc.
- **Focus states:** Existing `:focus-visible` styles in the app ensure keyboard focus is visible and accessible.

### Implementation

| Item | Description |
|------|-------------|
| **`useKeyboardShortcuts`** | Hook in `frontend/hooks/useKeyboardShortcuts.ts` that attaches a single `keydown` listener (capture phase), checks `isTypingElement(target)`, and handles `/`, `N`, and `Esc`. |
| **`KeyboardShortcuts`** | Client component that runs the hook; mounted once in the root layout so shortcuts work on all pages. |
| **Header** | Optional `showSearch` prop; when true, renders a search input with `data-shortcut="search"` and `aria-label="Search notes"`. Used on Dashboard and Notes. |
| **Create-note targets** | Dashboard "Create Note" link and Notes "Create Note" button have `data-shortcut="create-note"`. Link is focused (user can press Enter); button is focused and programmatically clicked. |
| **Esc and mobile menu** | Landing page listens for `shortcut-esc` and closes the mobile menu when Esc is pressed. |

### Other

- **Mobile menu button (hamburger):** Color and visibility were improved so the icon is clearly visible on the header and matches the theme (gray by default, blue on hover).

## Files Changed

- **New:** `frontend/hooks/useKeyboardShortcuts.ts`, `frontend/components/KeyboardShortcuts.tsx`
- **Modified:** `frontend/app/layout.tsx` (mount `KeyboardShortcuts`), `frontend/components/Header.tsx` (optional search, `data-shortcut="search"`), `frontend/app/dashboard/dashboard.tsx` (Header + create-note shortcut), `frontend/app/notes/notes.tsx` (Header + create-note shortcut), `frontend/app/page.tsx` (Esc closes mobile menu, hamburger styling)

## How to Test

1. **Dashboard** (`/dashboard`): Press `/` → search input should focus. Press `N` → "Create Note" link should focus (press Enter to go to Notes). Press `Esc` → focus should clear.
2. **Notes** (`/notes`): Press `/` → search input should focus. Press `N` → "Create Note" button should focus and trigger (placeholder action). Press `Esc` → focus should clear.
3. **Landing** (`/`): Open the mobile menu (hamburger), then press `Esc` → menu should close.
4. **No interference:** Focus the search input or any text field, then press `/`, `N`, or `Esc` → shortcut should **not** run (e.g. `/` should not refocus search while typing in it).
5. **Focus visibility:** Use Tab and shortcuts; focus ring should be visible on focused elements (existing focus-visible styles).

## Scope (as per issue)

- ✅ Frontend-only implementation  
- ✅ No backend or API changes  
- ✅ Works with existing UI and static data  
- ✅ No full feature implementations (placeholders acceptable for create-note)

## Documentation

- Shortcut behavior and “do not fire in inputs” logic are documented in JSDoc in `useKeyboardShortcuts.ts`.
- A short **Keyboard Shortcuts** section can be added to `frontend/README.md` (or contributor docs) listing `/`, `N`, and `Esc` for users and contributors.

## Checklist

- [x] Keyboard shortcuts work consistently on supported pages (Dashboard, Notes)
- [x] Focus states are visible and accessible
- [x] Shortcuts do not interfere with text input fields
- [x] Behavior documented (in code; README section optional)
