### PR TITLE
Add ARIA dialog roles to modal components

### DIFF
--- a/frontend/app/notes/notes.tsx
+++ b/frontend/app/notes/notes.tsx
@@ -207,7 +207,11 @@ export default function NotesPage() {
 
       {/* Create Note Modal */}
       {showCreateModal && canCreateNote && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+<div
+  role="dialog"
+  aria-modal="true"
+  className="fixed inset-0 bg-black/50 flex items-center justify-center"
+>
           <div className="bg-white p-6 rounded w-full max-w-md">
             <h2 className="text-xl font-semibold mb-4">New note</h2>
 


### PR DESCRIPTION
## Problem
Some modal components did not explicitly define appropriate ARIA roles.

Without role="dialog" and aria-modal="true", screen readers may not properly recognize modal context. This can cause confusion for users relying on assistive technologies.

## What This PR Does
- Adds role="dialog" to modal containers
- Adds aria-modal="true" to indicate modal behavior
- Improves semantic accessibility of modal components

## Why This Change Is Helpful
- Ensures screen readers correctly interpret modal context
- Improves accessibility compliance
- Aligns with WAI-ARIA best practices

## Scope
- Attribute-only change
- No styling updates
- No functional impact

## Expected Outcome
- Screen readers correctly announce modal dialogs
- Improved accessibility without UI or logic changes
- Zero regressions
