### PR TITLE
Fix invalid timestamps, improve empty state contrast, and keep notes …

### DIFF
--- a/frontend/app/notes/notes.tsx
+++ b/frontend/app/notes/notes.tsx
@@ -36,17 +36,26 @@ function saveNotesToStorage(notes: Note[]) {
   }
 }
 
-function formatRelativeTime(timestamp: number) {
+function formatRelativeTime(timestamp?: number) {
+  if (!timestamp || Number.isNaN(timestamp)) {
+    return "Created recently";
+  }
+
   const diff = Date.now() - timestamp;
+
+  if (Number.isNaN(diff) || diff < 0) {
+    return "Created recently";
+  }
+
   const minutes = Math.floor(diff / 60000);
   const hours = Math.floor(minutes / 60);
 
   if (minutes < 1) return "Created just now";
   if (minutes < 60)
     return `Created ${minutes} minute${minutes > 1 ? "s" : ""} ago`;
+
   return `Created ${hours} hour${hours > 1 ? "s" : ""} ago`;
 }
-
 export default function NotesPage() {
   const searchParams = useSearchParams();
   const search = searchParams.get("search") || "";
@@ -92,19 +101,19 @@ export default function NotesPage() {
         stored.length > 0
           ? stored
           : [
-              {
-                id: 1,
-                title: "Project Overview",
-                content: "A high-level overview of the project.",
-                createdAt: Date.now() - 1000 * 60 * 60, // 1 hour ago
-              },
-              {
-                id: 2,
-                title: "Meeting Notes",
-                content: "Key points from the last team sync.",
-                createdAt: Date.now() - 1000 * 60 * 5, // 5 minutes ago
-              },
-            ]
+            {
+              id: 1,
+              title: "Project Overview",
+              content: "A high-level overview of the project.",
+              createdAt: Date.now() - 1000 * 60 * 60, // 1 hour ago
+            },
+            {
+              id: 2,
+              title: "Meeting Notes",
+              content: "Key points from the last team sync.",
+              createdAt: Date.now() - 1000 * 60 * 5, // 5 minutes ago
+            },
+          ]
       );
       setIsLoading(false);
     }, 600);
@@ -212,26 +221,27 @@ export default function NotesPage() {
     <div className="flex">
       <Sidebar />
 
-      <div className="flex-1 flex flex-col min-w-0">
-        <Header
-          title="Notes"
-          showSearch
-          action={
-            canCreateNote ? (
-              <button
-                ref={createButtonRef}
-                type="button"
-                onClick={handleCreateNote}
-                className="btn-primary"
-              >
-                Create Note
-              </button>
-            ) : null
-          }
-        />
+      <div className="flex-1 flex flex-col min-w-0">        <Header
+        title="Notes"
+        showSearch
+        action={
+          canCreateNote ? (
+            <button
+              ref={createButtonRef}
+              type="button"
+              onClick={handleCreateNote}
+              className="btn-primary"
+            >
+              Create Note
+            </button>
+          ) : null
+        }
+      />
 
-        <main className="flex-1 overflow-auto" aria-busy={isLoading}>
-          <div className="max-w-3xl mx-auto p-6">
+        <main
+          className="flex-1 overflow-y-auto"
+          aria-busy={isLoading}
+        >         <div className="max-w-3xl mx-auto p-6">
             {createSuccessMessage && (
               <div
                 role="status"
@@ -398,8 +408,8 @@ export default function NotesPage() {
                   {isSubmitting
                     ? "Saving..."
                     : editingNoteId !== null
-                    ? "Update note"
-                    : "Create note"}
+                      ? "Update note"
+                      : "Create note"}
                 </button>
               </div>
             </form>

--- a/frontend/components/EmptyState.tsx
+++ b/frontend/components/EmptyState.tsx
@@ -45,13 +45,21 @@ export default function EmptyState({
             {icon}
           </div>
         )}
-        <h3 className="empty-state-title">{title}</h3>
-        {description && (
-          <p className="empty-state-description">{description}</p>
-        )}
-        {action && (
-          <div className="empty-state-action">{action}</div>
-        )}
+       <h3
+  className="empty-state-title"
+  style={{ color: "var(--color-text-primary)" }}
+>
+  {title}
+</h3>
+
+{description && (
+  <p
+    className="empty-state-description"
+    style={{ color: "var(--color-text-secondary)" }}
+  >
+    {description}
+  </p>
+)}
         {secondaryAction && (
           <div
             className="empty-state-action mt-2"

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -35,12 +35,13 @@ export default function Header({
         Skip to main content
       </a>
 
-      <header
-        className="flex items-center gap-4 border-b px-6 py-4"
-        role="banner"
-        style={{
-          background: "#000000",
-          borderColor: "rgba(255,255,255,0.08)",
+<header
+  className="sticky top-0 z-40 flex items-center gap-4 border-b px-6 py-4"
+  role="banner"
+  style={{
+    background: "#000000",
+    borderColor: "rgba(255,255,255,0.08)",
+  
           color: "#FFFFFF",
         }}
       >


### PR DESCRIPTION
## Overview

This PR fixes a few small but impactful UX and accessibility issues on the Notes page.  
The changes are frontend-only, low risk, and improve correctness, readability, and usability.

---

##  Fixes Included

### 1. Invalid timestamp shown as “Created NaN hour ago”
**Problem**
Some notes displayed invalid timestamps due to missing or malformed `createdAt` values.

**Fix**
- Added guards before formatting timestamps
- Fallback text is shown when timestamps are invalid

**Result**
- Notes now display `Created recently` instead of broken values

---

### 2. Empty state text had low contrast in dark mode
**Problem**
The “No results found” empty state text was hard to read on dark backgrounds.

**Fix**
- Updated text styles to use higher-contrast color tokens

**Result**
- Improved readability and accessibility (dark mode friendly)

---

### 3. Header and search bar disappeared on scroll
**Problem**
The notes header (including search) scrolled out of view when browsing long lists.

**Fix**
- Made the header sticky using `position: sticky`
- Ensured scrolling happens only inside the `<main>` container
- Added appropriate `z-index` and background styling

**Result**
- Header and search bar remain visible while scrolling
- Search is always accessible for large note lists

---

<img width="1893" height="867" alt="Screenshot 2026-02-20 205108" src="https://github.com/user-attachments/assets/abbe10f8-206b-4a30-83c3-3fbedd296e33" />
