### PR TITLE
Fix: Differentiate Home and Dashboard pages

### DIFF
--- a/frontend/app/workspace/[id]/page.tsx
+++ b/frontend/app/workspace/[id]/page.tsx
@@ -1,5 +1,47 @@
-import { redirect } from 'next/navigation';
+"use client";
 
-export default function WorkspacePage({ params }: { params: { id: string } }) {
-  redirect(`/workspace/${params.id}/dashboard`);
+import Link from "next/link";
+import Sidebar from "@/components/Sidebar";
+import Header from "@/components/Header";
+
+export default function WorkspaceHome({
+  params,
+}: {
+  params: { id: string };
+}) {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+
+      <div className="flex-1 flex flex-col">
+        <Header title="Home" />
+
+        <main className="p-8 max-w-3xl">
+          <h1 className="text-2xl font-semibold mb-2">
+            Welcome to your workspace 👋
+          </h1>
+
+          <p className="text-gray-500 mb-6">
+            This is your personal workspace. Use quick actions to get started.
+          </p>
+
+          <div className="flex gap-4">
+            <Link
+              href={`/workspace/${params.id}/notes?new=1`}
+              className="px-4 py-2 bg-black text-white rounded"
+            >
+              Create Note
+            </Link>
+
+            <Link
+              href={`/workspace/${params.id}/dashboard`}
+              className="px-4 py-2 border rounded"
+            >
+              Go to Dashboard
+            </Link>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Overview
Home and Dashboard pages were rendering nearly identical content, making it unclear to users what each page represents.

## Changes Made
- Updated Home page to act as a lightweight landing page
- Kept only welcome text and quick actions on Home
- Ensured "Go to Dashboard" navigates to the correct workspace-specific dashboard route
- Preserved Dashboard as the place for activity and overview content

## Why This Matters
- Improves clarity and navigation
- Aligns with common UX expectations
- Prevents confusion between Home and Dashboard
- Frontend-only change with low risk
<img width="1893" height="799" alt="Screenshot 2026-02-21 165900" src="https://github.com/user-attachments/assets/989843b2-f044-453a-aa23-d8bcc861307a" />
<img width="1894" height="754" alt="Screenshot 2026-02-21 170258" src="https://github.com/user-attachments/assets/d914ba42-a9e8-4daf-b04a-751de8f33563" />
