### PR TITLE
feat(editor): add copy note to clipboard action (#203)

### DIFF
--- a/frontend/components/CollaborativeEditor.tsx
+++ b/frontend/components/CollaborativeEditor.tsx
@@ -13,6 +13,15 @@ import { YSocketIOProvider } from '@/lib/yjs-provider';
 const CollaborativeEditor = ({ noteId, currentUser }: { noteId: string, currentUser: any }) => {
     const [ydoc] = useState(() => new Y.Doc());
     const [provider, setProvider] = useState<YSocketIOProvider | null>(null);
+    const [copied, setCopied] = useState(false);
+
+    const handleCopyNote = () => {
+        if (!editor) return;
+        const text = editor.getText();
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
 
     useEffect(() => {
         const prov = new YSocketIOProvider(socket, noteId, ydoc);
@@ -40,8 +49,33 @@ const CollaborativeEditor = ({ noteId, currentUser }: { noteId: string, currentU
     if (!provider) return <div>Connecting...</div>;
 
     return (
-        <div className="prose prose-lg max-w-none w-full p-4 border rounded-xl min-h-[300px] focus-within:ring-2 ring-blue-500/20 transition-all">
-             <EditorContent editor={editor} />
+        <div>
+            <div className="flex justify-end mb-2">
+                <button
+                    onClick={handleCopyNote}
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 dark:bg-stone-700 dark:hover:bg-stone-600 rounded-md transition-colors"
+                    title="Copy note to clipboard"
+                >
+                    {copied ? (
+                        <>
+                            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                            </svg>
+                            <span className="text-green-600">Copied!</span>
+                        </>
+                    ) : (
+                        <>
+                            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                            </svg>
+                            <span>Copy Note</span>
+                        </>
+                    )}
+                </button>
+            </div>
+            <div className="prose prose-lg max-w-none w-full p-4 border rounded-xl min-h-[300px] focus-within:ring-2 ring-blue-500/20 transition-all">
+                <EditorContent editor={editor} />
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
### Goal
Add a "Copy Note" button to the collaborative editor toolbar for quick text extraction.

### Changes
- Implemented "Copy Note" button in the editor toolbar.
- - Added functionality to copy plain text content to the clipboard.
- - Included a temporary "Copied!" success indicator for user feedback.
### Verification
- Manually verified the button correctly captures editor state and copies it to the clipboard.
- - Confirmed "Copied!" feedback is correctly displayed.