### PR TITLE
security: fix IDOR in workspace listing and missing auth on note fork/merge

### DIFF
--- a/backend/src/routes/notes.ts
+++ b/backend/src/routes/notes.ts
@@ -324,7 +324,7 @@ router.post('/:id/restore', authenticateToken, requirePermission('write'), async
 });
 
 // Fork a note to create a divergent copy
-router.post('/:id/fork', async (req: Request, res: Response) => {
+router.post('/:id/fork', authenticateToken, requirePermission('write'), async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;
     const { authorId, branchName } = req.body;
@@ -435,7 +435,7 @@ router.get('/:id/diff', authenticateToken, requirePermission('read'), async (req
 });
 
 // Merge a forked note back into the original
-router.post('/:id/merge', async (req: Request, res: Response) => {
+router.post('/:id/merge', authenticateToken, requirePermission('write'), async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;
     const { forkedNoteId, authorId, mergeStrategy = 'overwrite' } = req.body;

--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -73,8 +73,11 @@ router.post('/accept-invite', authenticateToken, async (req: AuthRequest, res: R
 });
 
 // Get workspaces for a user
-router.get('/user/:userId', authenticateToken, async (req: Request, res: Response) => {
+router.get('/user/:userId', authenticateToken, async (req: AuthRequest, res: Response) => {
   try {
+    if (req.user._id.toString() !== req.params.userId && req.user.role !== 'admin') {
+      return res.status(403).json({ error: 'Access denied' });
+    }
     const cacheService = getCacheService();
     const cacheKey = CacheKeys.userWorkspaces(req.params.userId);
 
@@ -100,9 +103,10 @@ router.get('/user/:userId', authenticateToken, async (req: Request, res: Respons
 });
 
 // Create a new workspace
-router.post('/', authenticateToken, async (req: Request, res: Response) => {
+router.post('/', authenticateToken, async (req: AuthRequest, res: Response) => {
   try {
-    const { name, description, ownerId } = req.body;
+    const { name, description } = req.body;
+    const ownerId = req.user!._id.toString();
     const workspace = new Workspace({ name, description, owner: ownerId });
     await workspace.save();
 


### PR DESCRIPTION
Closes #216

## Changes
- **fix(workspaces):** \`GET /user/:userId\` now verifies the authenticated user matches the requested userId, returning \`403\` if not
- **fix(workspaces):** \`POST /\` no longer accepts \`ownerId\` from the request body; owner is derived from the authenticated session
- **fix(notes):** \`POST /:id/fork\` and \`POST /:id/merge\` now require \[authenticateToken\]

## Security Impact
Prevents unauthorized access to other users' workspace lists (IDOR) and blocks unauthenticated note fork/merge operations."