### PR TITLE
add Workspace Templates — management, picker, built-ins

### DIFF
--- a/backend/src/models/Template.ts
+++ b/backend/src/models/Template.ts
@@ -1,0 +1,93 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export type TemplateCategory =
+  | 'meeting'
+  | 'rfc'
+  | 'design'
+  | 'project'
+  | 'bug_report'
+  | 'retrospective'
+  | 'onboarding'
+  | 'research'
+  | 'sprint'
+  | 'general';
+
+export type TemplateVisibility = 'private' | 'workspace' | 'public';
+
+export interface ITemplatePlaceholder {
+  name: string;         // e.g. "date", "attendees"
+  label: string;        // Human-readable label
+  type: 'text' | 'date' | 'list' | 'number';
+  defaultValue?: string;
+  description?: string;
+  required: boolean;
+}
+
+export interface ITemplate extends Document {
+  workspaceId: string | null;
+  ownerId: string;
+  title: string;
+  description: string;
+  category: TemplateCategory;
+  tags: string[];
+  body: string;               // Markdown body with {{placeholder}} syntax
+  placeholders: ITemplatePlaceholder[];
+  visibility: TemplateVisibility;
+  version: number;
+  usageCount: number;
+  previewContent: string;    // Short excerpt for card display (auto-generated)
+  isBuiltIn: boolean;        // True = system template, cannot be deleted
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const PlaceholderSchema = new Schema<ITemplatePlaceholder>(
+  {
+    name: { type: String, required: true },
+    label: { type: String, required: true },
+    type: { type: String, enum: ['text', 'date', 'list', 'number'], default: 'text' },
+    defaultValue: { type: String },
+    description: { type: String },
+    required: { type: Boolean, default: false },
+  },
+  { _id: false }
+);
+
+const TemplateSchema: Schema = new Schema<ITemplate>(
+  {
+    workspaceId: { type: String, default: null },
+    ownerId: { type: String, required: true },
+    title: { type: String, required: true, trim: true, maxlength: 120 },
+    description: { type: String, required: true, trim: true, maxlength: 500 },
+    category: {
+      type: String,
+      enum: ['meeting', 'rfc', 'design', 'project', 'bug_report', 'retrospective', 'onboarding', 'research', 'sprint', 'general'],
+      default: 'general',
+    },
+    tags: [{ type: String, trim: true }],
+    body: { type: String, required: true },
+    placeholders: { type: [PlaceholderSchema], default: [] },
+    visibility: {
+      type: String,
+      enum: ['private', 'workspace', 'public'],
+      default: 'workspace',
+    },
+    version: { type: Number, default: 1 },
+    usageCount: { type: Number, default: 0 },
+    previewContent: { type: String, default: '' },
+    isBuiltIn: { type: Boolean, default: false },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// Indexes for efficient queries
+TemplateSchema.index({ workspaceId: 1, category: 1 });
+TemplateSchema.index({ workspaceId: 1, visibility: 1 });
+TemplateSchema.index({ ownerId: 1 });
+TemplateSchema.index({ tags: 1 });
+TemplateSchema.index({ isBuiltIn: 1 });
+TemplateSchema.index({ title: 'text', description: 'text', tags: 'text' });
+
+export default mongoose.model<ITemplate>('Template', TemplateSchema);

--- a/backend/src/routes/templates.ts
+++ b/backend/src/routes/templates.ts
@@ -1,0 +1,352 @@
+import express, { Response } from 'express';
+import Template, { ITemplate, TemplateCategory, TemplateVisibility } from '../models/Template';
+import { authenticateToken, AuthRequest } from '../middleware/auth';
+import Workspace from '../models/Workspace';
+import { BUILT_IN_TEMPLATES } from '../services/templateSeedData';
+
+const router = express.Router();
+
+/* ─────────────────────────────────────────────────────────────────
+   Helper: verify that the requesting user is a member/owner of the
+   workspace and return their role. Throws with HTTP status codes.
+───────────────────────────────────────────────────────────────── */
+async function resolveWorkspaceRole(
+  workspaceId: string,
+  userId: string
+): Promise<'admin' | 'editor' | 'commenter' | 'viewer' | 'owner'> {
+  const workspace = await Workspace.findById(workspaceId);
+  if (!workspace) throw { status: 404, message: 'Workspace not found' };
+
+  if (workspace.owner === userId) return 'owner';
+
+  const member = workspace.members.find((m: any) => m.userId === userId);
+  if (!member) throw { status: 403, message: 'Not a member of this workspace' };
+
+  return member.role as 'admin' | 'editor' | 'commenter' | 'viewer';
+}
+
+function canEdit(role: string) {
+  return ['owner', 'admin', 'editor'].includes(role);
+}
+function canManage(role: string) {
+  return ['owner', 'admin'].includes(role);
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   GET /api/templates/builtin
+   Returns the built-in template library (no auth required).
+───────────────────────────────────────────────────────────────── */
+router.get('/builtin', (_req, res: Response) => {
+  res.json({ templates: BUILT_IN_TEMPLATES });
+});
+
+/* ─────────────────────────────────────────────────────────────────
+   GET /api/templates/workspace/:workspaceId
+   List templates visible to the requesting user in this workspace.
+   Includes: workspace-scoped templates + user's private templates
+   Query params: category, tags, search, visibility
+───────────────────────────────────────────────────────────────── */
+router.get('/workspace/:workspaceId', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    const { workspaceId } = req.params;
+    const userId = req.user._id.toString();
+    const { category, tags, search, visibility } = req.query;
+
+    await resolveWorkspaceRole(workspaceId, userId);
+
+    const query: any = {
+      $or: [
+        { workspaceId, visibility: { $in: ['workspace', 'public'] } },
+        { ownerId: userId, visibility: 'private' },
+        { visibility: 'public' },
+      ],
+    };
+
+    if (category) query.category = category;
+    if (visibility) {
+      // override the $or with precise visibility
+      delete query.$or;
+      query.workspaceId = workspaceId;
+      query.visibility = visibility;
+    }
+    if (tags) {
+      const tagList = (tags as string).split(',').map((t) => t.trim());
+      query.tags = { $in: tagList };
+    }
+    if (search) {
+      query.$text = { $search: search as string };
+    }
+
+    const templates = await Template.find(query)
+      .sort({ isBuiltIn: -1, usageCount: -1, updatedAt: -1 })
+      .select('-body -placeholders'); // lightweight list response
+
+    res.json({ templates });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message || 'Failed to fetch templates' });
+  }
+});
+
+/* ─────────────────────────────────────────────────────────────────
+   GET /api/templates/:id
+   Full template detail including body & placeholders.
+───────────────────────────────────────────────────────────────── */
+router.get('/:id', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    const { id } = req.params;
+    const userId = req.user._id.toString();
+
+    const template = await Template.findById(id);
+    if (!template) return res.status(404).json({ error: 'Template not found' });
+
+    // Private templates only readable by their owner
+    if (template.visibility === 'private' && template.ownerId !== userId) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    // Workspace templates require membership
+    if (template.workspaceId && template.visibility === 'workspace') {
+      await resolveWorkspaceRole(template.workspaceId, userId);
+    }
+
+    res.json({ template });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message || 'Failed to fetch template' });
+  }
+});
+
+/* ─────────────────────────────────────────────────────────────────
+   POST /api/templates/workspace/:workspaceId
+   Create a new template (editor+ roles can create workspace templates,
+   any member can create private templates).
+───────────────────────────────────────────────────────────────── */
+router.post('/workspace/:workspaceId', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    const { workspaceId } = req.params;
+    const userId = req.user._id.toString();
+
+    const role = await resolveWorkspaceRole(workspaceId, userId);
+
+    const { title, description, category, tags, body, placeholders, visibility } = req.body;
+
+    // Only editors+ can create workspace-visible templates
+    const requestedVisibility: TemplateVisibility = visibility || 'workspace';
+    if (requestedVisibility !== 'private' && !canEdit(role)) {
+      return res.status(403).json({ error: 'Only editors or admins can create shared templates' });
+    }
+
+    if (!title || !body) {
+      return res.status(400).json({ error: 'title and body are required' });
+    }
+
+    const previewContent = body.replace(/[#*`\[\]_>]/g, '').slice(0, 200).trim();
+
+    const template = new Template({
+      workspaceId,
+      ownerId: userId,
+      title: title.trim(),
+      description: (description || '').trim(),
+      category: category || 'general',
+      tags: Array.isArray(tags) ? tags.map((t: string) => t.trim()) : [],
+      body,
+      placeholders: Array.isArray(placeholders) ? placeholders : [],
+      visibility: requestedVisibility,
+      version: 1,
+      usageCount: 0,
+      previewContent,
+      isBuiltIn: false,
+    });
+
+    await template.save();
+    res.status(201).json({ template });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message || 'Failed to create template' });
+  }
+});
+
+/* ─────────────────────────────────────────────────────────────────
+   PUT /api/templates/:id
+   Update a template. Owner or admin can edit; version bumps auto.
+───────────────────────────────────────────────────────────────── */
+router.put('/:id', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    const { id } = req.params;
+    const userId = req.user._id.toString();
+
+    const template = await Template.findById(id);
+    if (!template) return res.status(404).json({ error: 'Template not found' });
+    if (template.isBuiltIn) return res.status(403).json({ error: 'Built-in templates cannot be modified' });
+
+    // Must be owner, or workspace admin/owner
+    const isOwner = template.ownerId === userId;
+    let role = '';
+    if (template.workspaceId) {
+      try {
+        role = await resolveWorkspaceRole(template.workspaceId, userId);
+      } catch (_) {}
+    }
+
+    if (!isOwner && !canManage(role)) {
+      return res.status(403).json({ error: 'Only the template owner or workspace admins can edit this template' });
+    }
+
+    const { title, description, category, tags, body, placeholders, visibility } = req.body;
+
+    if (title !== undefined) template.title = title.trim();
+    if (description !== undefined) template.description = description.trim();
+    if (category !== undefined) template.category = category;
+    if (tags !== undefined) template.tags = Array.isArray(tags) ? tags.map((t: string) => t.trim()) : [];
+    if (body !== undefined) {
+      template.body = body;
+      template.previewContent = body.replace(/[#*`\[\]_>]/g, '').slice(0, 200).trim();
+    }
+    if (placeholders !== undefined) template.placeholders = placeholders;
+    if (visibility !== undefined) template.visibility = visibility;
+
+    template.version += 1;
+    await template.save();
+
+    res.json({ template });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message || 'Failed to update template' });
+  }
+});
+
+/* ─────────────────────────────────────────────────────────────────
+   DELETE /api/templates/:id
+   Delete a template. Owner or workspace admin only.
+───────────────────────────────────────────────────────────────── */
+router.delete('/:id', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    const { id } = req.params;
+    const userId = req.user._id.toString();
+
+    const template = await Template.findById(id);
+    if (!template) return res.status(404).json({ error: 'Template not found' });
+    if (template.isBuiltIn) return res.status(403).json({ error: 'Built-in templates cannot be deleted' });
+
+    const isOwner = template.ownerId === userId;
+    let role = '';
+    if (template.workspaceId) {
+      try { role = await resolveWorkspaceRole(template.workspaceId, userId); } catch (_) {}
+    }
+
+    if (!isOwner && !canManage(role)) {
+      return res.status(403).json({ error: 'Insufficient permissions to delete this template' });
+    }
+
+    await Template.findByIdAndDelete(id);
+    res.json({ deleted: true, id });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message || 'Failed to delete template' });
+  }
+});
+
+/* ─────────────────────────────────────────────────────────────────
+   POST /api/templates/:id/copy
+   Copy (fork) a template into the user's workspace or as private.
+───────────────────────────────────────────────────────────────── */
+router.post('/:id/copy', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    const { id } = req.params;
+    const userId = req.user._id.toString();
+    const { targetWorkspaceId, visibility = 'workspace' } = req.body;
+
+    const source = await Template.findById(id);
+    if (!source) return res.status(404).json({ error: 'Template not found' });
+
+    let workspaceId = targetWorkspaceId || source.workspaceId;
+    if (workspaceId) {
+      await resolveWorkspaceRole(workspaceId, userId);
+    }
+
+    const copied = new Template({
+      workspaceId: workspaceId || null,
+      ownerId: userId,
+      title: `${source.title} (Copy)`,
+      description: source.description,
+      category: source.category,
+      tags: [...source.tags],
+      body: source.body,
+      placeholders: source.placeholders.map((p) => ({ ...p })),
+      visibility: visibility as TemplateVisibility,
+      version: 1,
+      usageCount: 0,
+      previewContent: source.previewContent,
+      isBuiltIn: false,
+    });
+
+    await copied.save();
+    res.status(201).json({ template: copied });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message || 'Failed to copy template' });
+  }
+});
+
+/* ─────────────────────────────────────────────────────────────────
+   POST /api/templates/:id/use
+   Increment usageCount and return the rendered body with
+   placeholders replaced by provided values.
+───────────────────────────────────────────────────────────────── */
+router.post('/:id/use', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { values = {} } = req.body; // { placeholderName: value }
+
+    const template = await Template.findById(id);
+    if (!template) return res.status(404).json({ error: 'Template not found' });
+
+    // Replace placeholders
+    let rendered = template.body;
+    for (const [key, val] of Object.entries(values)) {
+      const regex = new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, 'g');
+      rendered = rendered.replace(regex, String(val));
+    }
+
+    // Increment usage counter (fire-and-forget)
+    Template.findByIdAndUpdate(id, { $inc: { usageCount: 1 } }).exec().catch(() => {});
+
+    res.json({ title: template.title, body: rendered });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message || 'Failed to apply template' });
+  }
+});
+
+/* ─────────────────────────────────────────────────────────────────
+   POST /api/templates/seed/:workspaceId
+   Seed built-in templates for a workspace (admin only, idempotent).
+───────────────────────────────────────────────────────────────── */
+router.post('/seed/:workspaceId', authenticateToken, async (req: AuthRequest, res: Response) => {
+  try {
+    const { workspaceId } = req.params;
+    const userId = req.user._id.toString();
+
+    const role = await resolveWorkspaceRole(workspaceId, userId);
+    if (!canManage(role)) {
+      return res.status(403).json({ error: 'Only workspace admins can seed templates' });
+    }
+
+    let seeded = 0;
+    for (const tpl of BUILT_IN_TEMPLATES) {
+      const exists = await Template.findOne({ workspaceId, title: tpl.title, isBuiltIn: true });
+      if (!exists) {
+        const previewContent = tpl.body.replace(/[#*`\[\]_>]/g, '').slice(0, 200).trim();
+        await new Template({
+          ...tpl,
+          workspaceId,
+          ownerId: userId,
+          previewContent,
+          version: 1,
+          usageCount: 0,
+        }).save();
+        seeded++;
+      }
+    }
+
+    res.json({ seeded, total: BUILT_IN_TEMPLATES.length });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message || 'Failed to seed templates' });
+  }
+});
+
+export default router;

--- a/backend/src/services/templateSeedData.ts
+++ b/backend/src/services/templateSeedData.ts
@@ -1,0 +1,706 @@
+import { ITemplatePlaceholder, TemplateCategory, TemplateVisibility } from '../models/Template';
+
+export interface BuiltInTemplate {
+  title: string;
+  description: string;
+  category: TemplateCategory;
+  tags: string[];
+  body: string;
+  placeholders: ITemplatePlaceholder[];
+  visibility: TemplateVisibility;
+  isBuiltIn: true;
+}
+
+export const BUILT_IN_TEMPLATES: BuiltInTemplate[] = [
+  {
+    title: 'Meeting Notes',
+    description:
+      'Structured format for recording meeting discussions, decisions, and action items. Ideal for recurring standups, planning sessions, and reviews.',
+    category: 'meeting',
+    tags: ['meeting', 'standup', 'collaboration'],
+    visibility: 'public',
+    isBuiltIn: true,
+    placeholders: [
+      { name: 'date', label: 'Meeting Date', type: 'date', required: true, defaultValue: '', description: 'Date the meeting was held' },
+      { name: 'attendees', label: 'Attendees', type: 'list', required: true, defaultValue: '', description: 'Comma-separated list of participants' },
+      { name: 'facilitator', label: 'Facilitator', type: 'text', required: false, defaultValue: '', description: 'Meeting facilitator name' },
+    ],
+    body: `# Meeting Notes — {{date}}
+
+**Facilitator:** {{facilitator}}
+**Attendees:** {{attendees}}
+
+---
+
+## 📋 Agenda
+
+1. 
+2. 
+3. 
+
+---
+
+## 📝 Discussion
+
+### Topic 1
+
+
+### Topic 2
+
+
+### Topic 3
+
+
+---
+
+## ✅ Decisions Made
+
+- 
+
+---
+
+## 🎯 Action Items
+
+| # | Task | Owner | Due Date | Status |
+|---|------|-------|----------|--------|
+| 1 |  |  |  | 🔲 Open |
+| 2 |  |  |  | 🔲 Open |
+
+---
+
+## 📌 Next Meeting
+
+**Date:** 
+**Topics to carry forward:**
+- 
+
+---
+
+*Notes recorded by: {{facilitator}}*
+`,
+  },
+
+  {
+    title: 'RFC — Request for Comments',
+    description:
+      'Formal proposal format for discussing significant technical or product decisions with stakeholders before implementation begins.',
+    category: 'rfc',
+    tags: ['rfc', 'proposal', 'technical', 'decision'],
+    visibility: 'public',
+    isBuiltIn: true,
+    placeholders: [
+      { name: 'rfc_number', label: 'RFC Number', type: 'number', required: true, defaultValue: '', description: 'Sequential RFC identifier' },
+      { name: 'title', label: 'RFC Title', type: 'text', required: true, defaultValue: '', description: 'Short, descriptive title for the proposal' },
+      { name: 'author', label: 'Author(s)', type: 'text', required: true, defaultValue: '', description: 'Primary author(s) of this RFC' },
+      { name: 'date', label: 'Date', type: 'date', required: true, defaultValue: '', description: 'Submission date' },
+    ],
+    body: `# RFC-{{rfc_number}}: {{title}}
+
+**Author:** {{author}}
+**Date:** {{date}}
+**Status:** \`Draft\` <!-- Draft | In Review | Accepted | Rejected | Superseded -->
+
+---
+
+## Summary
+
+> _A one-paragraph summary of the proposal. What is it, and why does it matter?_
+
+---
+
+## Motivation
+
+### Problem Statement
+
+_Describe the problem this RFC is solving. Why do we need this change?_
+
+### Goals
+
+- 
+- 
+
+### Non-Goals
+
+- 
+
+---
+
+## Detailed Design
+
+_Provide the full technical or design specification. Include diagrams, API contracts, data models, or user flows as appropriate._
+
+### Proposed Solution
+
+
+### Alternatives Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Option A |  |  |
+| Option B (proposed) |  |  |
+
+---
+
+## Implementation Plan
+
+### Phases
+
+1. **Phase 1** — 
+2. **Phase 2** — 
+3. **Phase 3** — 
+
+### Estimated Effort
+
+| Area | Estimate |
+|------|----------|
+| Backend |  |
+| Frontend |  |
+| Testing |  |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+|  | Medium | High |  |
+
+---
+
+## Open Questions
+
+- [ ] 
+- [ ] 
+
+---
+
+## References
+
+- 
+- 
+
+---
+
+*RFC status changes and comments should be tracked in the discussion thread below this document.*
+`,
+  },
+
+  {
+    title: 'Architecture Decision Record (ADR)',
+    description:
+      'Capture architectural decisions and their context. Helps teams understand why design choices were made, especially for future reference.',
+    category: 'design',
+    tags: ['adr', 'architecture', 'design', 'decision'],
+    visibility: 'public',
+    isBuiltIn: true,
+    placeholders: [
+      { name: 'adr_number', label: 'ADR Number', type: 'number', required: true, defaultValue: '', description: 'Sequential ADR identifier' },
+      { name: 'title', label: 'Decision Title', type: 'text', required: true, defaultValue: '', description: 'Short title for the decision' },
+      { name: 'date', label: 'Date', type: 'date', required: true, defaultValue: '', description: 'Decision date' },
+      { name: 'deciders', label: 'Deciders', type: 'list', required: true, defaultValue: '', description: 'People involved in making this decision' },
+    ],
+    body: `# ADR-{{adr_number}}: {{title}}
+
+**Date:** {{date}}
+**Status:** \`Proposed\` <!-- Proposed | Accepted | Deprecated | Superseded by ADR-XXX -->
+**Deciders:** {{deciders}}
+
+---
+
+## Context
+
+_Describe the forces at play — technical, political, social, and project-specific. These forces are probably in tension, and should be named._
+
+
+---
+
+## Decision
+
+_The change that we're proposing or have agreed to implement, stated clearly and concisely._
+
+
+---
+
+## Consequences
+
+### Positive
+
+- 
+
+### Negative
+
+- 
+
+### Neutral
+
+- 
+
+---
+
+## Options Considered
+
+### Option 1 (Selected): 
+
+**Pros:**
+- 
+
+**Cons:**
+- 
+
+### Option 2: 
+
+**Pros:**
+- 
+
+**Cons:**
+- 
+
+---
+
+## Implementation Notes
+
+_Any technical notes or considerations for teams implementing this decision._
+
+---
+
+*This ADR supersedes: N/A*
+*This ADR is superseded by: N/A*
+`,
+  },
+
+  {
+    title: 'Bug Report',
+    description:
+      'Comprehensive bug report format for engineering teams. Captures reproduction steps, environment details, expected vs actual behaviour, and links to related work.',
+    category: 'bug_report',
+    tags: ['bug', 'defect', 'engineering', 'qa'],
+    visibility: 'public',
+    isBuiltIn: true,
+    placeholders: [
+      { name: 'bug_id', label: 'Bug / Ticket ID', type: 'text', required: false, defaultValue: '', description: 'Reference ID from your issue tracker' },
+      { name: 'reporter', label: 'Reported By', type: 'text', required: true, defaultValue: '', description: 'Name of the person reporting' },
+      { name: 'date', label: 'Date', type: 'date', required: true, defaultValue: '', description: 'Date this was reported' },
+    ],
+    body: `# Bug Report — {{bug_id}}
+
+**Reported By:** {{reporter}}
+**Date:** {{date}}
+**Severity:** \`Critical\` <!-- Critical | High | Medium | Low -->
+**Priority:** \`P1\` <!-- P1 | P2 | P3 | P4 -->
+**Status:** \`Open\` <!-- Open | In Progress | Resolved | Won't Fix | Duplicate -->
+
+---
+
+## Summary
+
+_One-line description of the bug._
+
+---
+
+## Environment
+
+| Field | Value |
+|-------|-------|
+| OS | |
+| Browser / Client | |
+| App Version | |
+| Environment | Production / Staging / Dev |
+| User Role | |
+
+---
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+4. 
+
+---
+
+## Expected Behaviour
+
+_What should happen?_
+
+---
+
+## Actual Behaviour
+
+_What actually happens?_
+
+---
+
+## Screenshots / Logs
+
+_Attach screenshots, video recordings, or relevant log snippets._
+
+\`\`\`
+Paste error logs here
+\`\`\`
+
+---
+
+## Root Cause Analysis
+
+_Once investigated, document the root cause here._
+
+---
+
+## Proposed Fix
+
+_Optional: If you have a suggested fix, describe it here._
+
+---
+
+## Related Issues / PRs
+
+- 
+`,
+  },
+
+  {
+    title: 'Sprint Planning',
+    description:
+      'Organise sprint goals, capacity, and task breakdowns. Provides a single source of truth for the team during the sprint.',
+    category: 'sprint',
+    tags: ['agile', 'sprint', 'planning', 'engineering'],
+    visibility: 'public',
+    isBuiltIn: true,
+    placeholders: [
+      { name: 'sprint_number', label: 'Sprint Number', type: 'number', required: true, defaultValue: '', description: 'Sprint iteration number' },
+      { name: 'start_date', label: 'Sprint Start', type: 'date', required: true, defaultValue: '', description: 'Sprint start date' },
+      { name: 'end_date', label: 'Sprint End', type: 'date', required: true, defaultValue: '', description: 'Sprint end date' },
+      { name: 'team', label: 'Team Members', type: 'list', required: true, defaultValue: '', description: 'Comma-separated team members' },
+    ],
+    body: `# Sprint {{sprint_number}} Planning
+
+**Period:** {{start_date}} → {{end_date}}
+**Team:** {{team}}
+
+---
+
+## 🎯 Sprint Goal
+
+_A single, concise statement describing what success looks like at the end of this sprint._
+
+---
+
+## 📊 Capacity
+
+| Team Member | Available Days | Story Points |
+|-------------|---------------|-------------|
+|  |  |  |
+|  |  |  |
+| **Total** | | |
+
+---
+
+## 📋 Sprint Backlog
+
+### Must-Have (P0)
+
+| ID | Title | Assignee | Points | Status |
+|----|-------|----------|--------|--------|
+|  |  |  |  | 🔲 To Do |
+|  |  |  |  | 🔲 To Do |
+
+### Should-Have (P1)
+
+| ID | Title | Assignee | Points | Status |
+|----|-------|----------|--------|--------|
+|  |  |  |  | 🔲 To Do |
+
+### Nice-to-Have (P2)
+
+| ID | Title | Assignee | Points | Status |
+|----|-------|----------|--------|--------|
+|  |  |  |  | 🔲 To Do |
+
+---
+
+## 🚧 Dependencies & Blockers
+
+- 
+
+---
+
+## 📝 Notes & Agreements
+
+- 
+
+---
+
+## Definition of Done
+
+- [ ] Code reviewed and approved
+- [ ] Tests written and passing
+- [ ] Documentation updated
+- [ ] Deployed to staging
+- [ ] Acceptance criteria met
+`,
+  },
+
+  {
+    title: 'Project Brief',
+    description:
+      'High-level project overview for aligning stakeholders on scope, objectives, and timelines at the start of a new initiative.',
+    category: 'project',
+    tags: ['project', 'brief', 'planning', 'stakeholders'],
+    visibility: 'public',
+    isBuiltIn: true,
+    placeholders: [
+      { name: 'project_name', label: 'Project Name', type: 'text', required: true, defaultValue: '', description: 'Official project name' },
+      { name: 'owner', label: 'Project Owner', type: 'text', required: true, defaultValue: '', description: 'DRI / Project Owner' },
+      { name: 'date', label: 'Date', type: 'date', required: true, defaultValue: '', description: 'Brief creation date' },
+    ],
+    body: `# Project Brief: {{project_name}}
+
+**Owner:** {{owner}}
+**Date:** {{date}}
+**Phase:** \`Discovery\` <!-- Discovery | Planning | Execution | Review | Closed -->
+
+---
+
+## Executive Summary
+
+_2–3 sentences describing what this project is and why it's being done now._
+
+---
+
+## Problem Statement
+
+_What problem or opportunity does this project address?_
+
+---
+
+## Objectives & Success Metrics
+
+| Objective | Key Result / Metric | Target |
+|-----------|--------------------|---------| 
+|  |  |  |
+|  |  |  |
+
+---
+
+## Scope
+
+### In Scope
+- 
+
+### Out of Scope
+- 
+
+---
+
+## Stakeholders
+
+| Name | Role | Involvement |
+|------|------|-------------|
+|  | Sponsor | Approver |
+|  | PM | DRI |
+|  | Engineering | Core Team |
+
+---
+
+## Timeline
+
+| Milestone | Target Date | Status |
+|-----------|------------|--------|
+| Kickoff |  | 🔲 |
+| Design complete |  | 🔲 |
+| Build complete |  | 🔲 |
+| Launch |  | 🔲 |
+
+---
+
+## Budget / Resources
+
+_Resources required: headcount, tools, infrastructure estimate._
+
+---
+
+## Risks
+
+| Risk | Likelihood | Impact | Owner |
+|------|-----------|--------|-------|
+|  | Medium | High |  |
+
+---
+
+## Open Questions
+
+- [ ] 
+- [ ] 
+`,
+  },
+
+  {
+    title: 'Retrospective',
+    description:
+      'Post-sprint or post-project retrospective to reflect on what went well, what didn\'t, and what to improve. Based on the Start / Stop / Continue format.',
+    category: 'retrospective',
+    tags: ['retro', 'agile', 'retrospective', 'team'],
+    visibility: 'public',
+    isBuiltIn: true,
+    placeholders: [
+      { name: 'sprint_or_project', label: 'Sprint / Project', type: 'text', required: true, defaultValue: '', description: 'Sprint number or project name' },
+      { name: 'date', label: 'Date', type: 'date', required: true, defaultValue: '', description: 'Retro date' },
+      { name: 'facilitator', label: 'Facilitator', type: 'text', required: false, defaultValue: '', description: 'Facilitator name' },
+    ],
+    body: `# Retrospective — {{sprint_or_project}}
+
+**Date:** {{date}}
+**Facilitator:** {{facilitator}}
+
+---
+
+## ✅ What Went Well (Keep Doing)
+
+_Practices, decisions, or behaviours the team should continue._
+
+- 
+- 
+
+---
+
+## ❌ What Didn't Go Well (Stop Doing)
+
+_Things that hindered progress or caused friction._
+
+- 
+- 
+
+---
+
+## 💡 What Should We Try (Start Doing)
+
+_New ideas, experiments, or process changes to attempt._
+
+- 
+- 
+
+---
+
+## 🎯 Action Items
+
+| # | Action | Owner | Due | Status |
+|---|--------|-------|-----|--------|
+| 1 |  |  |  | 🔲 |
+| 2 |  |  |  | 🔲 |
+
+---
+
+## 📊 Team Metrics (Optional)
+
+| Metric | This Sprint | Last Sprint | Trend |
+|--------|-------------|-------------|-------|
+| Velocity |  |  | |
+| Bug count |  |  | |
+| Deploy frequency |  |  | |
+
+---
+
+## 😊 Team Mood
+
+_Rate team morale 1–5 and note key factors._
+
+**Score:** /5
+**Factors:**
+- 
+`,
+  },
+
+  {
+    title: 'Research Notes',
+    description:
+      'Structured template for documenting research findings, sources, and insights. Suitable for user research, competitive analysis, or technical exploration.',
+    category: 'research',
+    tags: ['research', 'notes', 'discovery', 'analysis'],
+    visibility: 'public',
+    isBuiltIn: true,
+    placeholders: [
+      { name: 'topic', label: 'Research Topic', type: 'text', required: true, defaultValue: '', description: 'The subject of research' },
+      { name: 'researcher', label: 'Researcher', type: 'text', required: true, defaultValue: '', description: 'Name of researcher' },
+      { name: 'date', label: 'Date', type: 'date', required: true, defaultValue: '', description: 'Research date' },
+    ],
+    body: `# Research Notes: {{topic}}
+
+**Researcher:** {{researcher}}
+**Date:** {{date}}
+**Status:** \`In Progress\` <!-- In Progress | Complete | Archived -->
+
+---
+
+## Research Question(s)
+
+1. 
+2. 
+
+---
+
+## Methodology
+
+_How was this research conducted? (desk research, interviews, surveys, analysis, experiments)_
+
+---
+
+## Key Findings
+
+### Finding 1
+
+
+
+### Finding 2
+
+
+
+### Finding 3
+
+
+
+---
+
+## Supporting Evidence
+
+| Finding | Source | Quote / Data |
+|---------|--------|--------------|
+|  |  |  |
+|  |  |  |
+
+---
+
+## Patterns & Insights
+
+_What patterns emerged? What does this mean for the team or product?_
+
+-  
+
+---
+
+## Gaps & Open Questions
+
+_What questions remain unanswered? What research is needed next?_
+
+- [ ] 
+- [ ] 
+
+---
+
+## References
+
+| # | Source | Link | Date Accessed |
+|---|--------|------|---------------|
+| 1 |  |  |  |
+| 2 |  |  |  |
+
+---
+
+## Recommendations
+
+_Based on the research, what do you recommend?_
+
+1. 
+2. 
+`,
+  },
+];

--- a/frontend/app/workspace/[id]/templates/page.tsx
+++ b/frontend/app/workspace/[id]/templates/page.tsx
@@ -1,0 +1,886 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useParams } from "next/navigation";
+import Sidebar from "@/components/Sidebar";
+import Header from "@/components/Header";
+import RouteGuard from "@/components/RouteGuard";
+import TemplateCard, { CATEGORY_META } from "@/components/TemplateCard";
+import TemplateEditorModal from "@/components/TemplateEditorModal";
+import TemplatePicker from "@/components/TemplatePicker";
+import { useTemplates } from "@/hooks/useTemplates";
+import { usePermissions } from "@/hooks/usePermissions";
+import type { Template, TemplateCategory } from "@/lib/api";
+
+type SortKey = "name" | "usage" | "updated";
+type ViewMode = "grid" | "list";
+
+export default function TemplatesPage() {
+  const params = useParams();
+  const workspaceId = (params?.id as string) || "";
+
+  const {
+    templates,
+    loading,
+    error,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+    copyTemplate,
+    useTemplate,
+    seedBuiltIns,
+    refetch,
+  } = useTemplates(workspaceId);
+
+  const { isAdmin } = usePermissions();
+
+  /* ── UI State ─────────────────────────────────────────────── */
+  const [search, setSearch] = useState("");
+  const [activeCategory, setActiveCategory] = useState<TemplateCategory | "all">("all");
+  const [activeVisibility, setActiveVisibility] = useState<"all" | "private" | "workspace" | "public">("all");
+  const [sortKey, setSortKey] = useState<SortKey>("usage");
+  const [viewMode, setViewMode] = useState<ViewMode>("grid");
+
+  /* Modal state */
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<Template | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [previewTemplate, setPreviewTemplate] = useState<Template | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Template | null>(null);
+  const [seeding, setSeeding] = useState(false);
+  const [seedMsg, setSeedMsg] = useState("");
+  const [appliedMsg, setAppliedMsg] = useState("");
+
+  /* ── Derived data ─────────────────────────────────────────── */
+  const categories = useMemo(() => {
+    const cats = new Set(templates.map((t) => t.category));
+    return Array.from(cats) as TemplateCategory[];
+  }, [templates]);
+
+  const filtered = useMemo(() => {
+    let list = [...templates];
+
+    if (activeCategory !== "all") list = list.filter((t) => t.category === activeCategory);
+    if (activeVisibility !== "all") list = list.filter((t) => t.visibility === activeVisibility);
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      list = list.filter(
+        (t) =>
+          t.title.toLowerCase().includes(q) ||
+          t.description.toLowerCase().includes(q) ||
+          t.tags.some((tag) => tag.toLowerCase().includes(q))
+      );
+    }
+
+    list.sort((a, b) => {
+      if (sortKey === "name") return a.title.localeCompare(b.title);
+      if (sortKey === "usage") return b.usageCount - a.usageCount;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    });
+
+    return list;
+  }, [templates, activeCategory, activeVisibility, search, sortKey]);
+
+  /* built-in vs custom split */
+  const builtInTemplates = filtered.filter((t) => t.isBuiltIn);
+  const customTemplates = filtered.filter((t) => !t.isBuiltIn);
+
+  /* ── Handlers ─────────────────────────────────────────────── */
+  async function handleSeed() {
+    setSeeding(true);
+    setSeedMsg("");
+    try {
+      const r = await seedBuiltIns();
+      setSeedMsg(
+        r.seeded === 0
+          ? "Built-in templates are already up to date."
+          : `Added ${r.seeded} built-in template${r.seeded !== 1 ? "s" : ""}.`
+      );
+    } catch {
+      setSeedMsg("Failed to seed templates.");
+    } finally {
+      setSeeding(false);
+    }
+  }
+
+  async function handleSave(data: Partial<Template>) {
+    if (editTarget) {
+      await updateTemplate(editTarget._id, data);
+    } else {
+      await createTemplate({ ...data, workspaceId });
+    }
+  }
+
+  async function handleDelete(template: Template) {
+    await deleteTemplate(template._id);
+    setDeleteTarget(null);
+  }
+
+  async function handleCopy(template: Template) {
+    await copyTemplate(template._id, "workspace");
+  }
+
+  function openEditor(template?: Template) {
+    setEditTarget(template || null);
+    setEditorOpen(true);
+  }
+
+  function handleApplyFromPicker(_title: string, body: string) {
+    setPickerOpen(false);
+    setAppliedMsg("Template applied! The content has been copied — paste it into your note.");
+    setTimeout(() => setAppliedMsg(""), 5000);
+    // Copy to clipboard for convenience
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(body).catch(() => {});
+    }
+  }
+
+  /* ── Stats ─────────────────────────────────────────────────── */
+  const totalUses = templates.reduce((s, t) => s + t.usageCount, 0);
+  const customCount = templates.filter((t) => !t.isBuiltIn).length;
+
+  return (
+    <RouteGuard requireAuth>
+      <div className="flex min-h-screen bg-[var(--color-background)] text-stone-900">
+        <Sidebar />
+
+        <div className="flex-1 flex flex-col min-w-0">
+          <Header title="Templates" showSearch={false} />
+
+          <main className="flex-1 overflow-auto">
+            {/* ── Hero header ──────────────────────────────────── */}
+            <div className="px-8 pt-8 pb-6 border-b border-stone-200">
+              <div className="max-w-6xl mx-auto">
+                <div className="flex items-start justify-between gap-6 flex-wrap">
+                  <div>
+                    <h1 className="text-3xl font-bold text-stone-900 tracking-tight">
+                      Workspace Templates
+                    </h1>
+                    <p className="text-stone-700 mt-1.5 text-sm max-w-xl">
+                      Reusable note structures for meetings, RFCs, project briefs, and more. Apply a
+                      template to start a new note with professional structure in seconds.
+                    </p>
+                  </div>
+
+                  <div className="flex items-center gap-3 shrink-0">
+                    <button
+                      onClick={handleSeed}
+                      disabled={seeding}
+                      className="flex items-center gap-2 px-4 py-2 text-sm text-stone-700 border border-stone-200
+                        rounded-lg hover:text-stone-900 hover:border-stone-300 transition-colors disabled:opacity-50"
+                    >
+                      {seeding ? (
+                        <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                      ) : (
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                      )}
+                      Sync Built-ins
+                    </button>
+
+                    <button
+                      onClick={() => setPickerOpen(true)}
+                      className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-stone-700 border border-stone-200
+                        rounded-lg hover:text-stone-900 hover:border-stone-300 transition-colors"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                      </svg>
+                      Browse & Apply
+                    </button>
+
+                    <button
+                      onClick={() => openEditor()}
+                      className="flex items-center gap-2 px-5 py-2 text-sm font-medium bg-white text-black
+                        rounded-lg hover:bg-stone-200 transition-colors"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                      </svg>
+                      New Template
+                    </button>
+                  </div>
+                </div>
+
+                {/* Stats row */}
+                <div className="flex items-center gap-6 mt-6">
+                  {[
+                    { label: "Total templates", value: templates.length },
+                    { label: "Custom templates", value: customCount },
+                    { label: "Total uses", value: totalUses },
+                    { label: "Categories", value: categories.length },
+                  ].map((stat) => (
+                    <div key={stat.label} className="flex flex-col gap-0.5">
+                      <span className="text-2xl font-bold text-stone-900">{stat.value}</span>
+                      <span className="text-xs text-stone-600">{stat.label}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* ── Notifications ──────────────────────────────────── */}
+            {seedMsg && (
+              <div className="mx-8 mt-4 max-w-6xl mx-auto">
+                <div className="flex items-center gap-2 px-4 py-3 bg-green-500/10 border border-green-500/20 rounded-xl text-sm text-green-400">
+                  <svg className="w-4 h-4 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                  </svg>
+                  {seedMsg}
+                </div>
+              </div>
+            )}
+
+            {appliedMsg && (
+              <div className="mx-8 mt-4">
+                <div className="max-w-6xl mx-auto flex items-center gap-2 px-4 py-3 bg-blue-500/10 border border-blue-500/20 rounded-xl text-sm text-blue-400">
+                  <svg className="w-4 h-4 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                  </svg>
+                  {appliedMsg}
+                </div>
+              </div>
+            )}
+
+            {error && (
+              <div className="mx-8 mt-4">
+                <div className="max-w-6xl mx-auto px-4 py-3 bg-red-500/10 border border-red-500/20 rounded-xl text-sm text-red-400">
+                  {error}
+                </div>
+
+                {/* Helpful CTA when permission is denied */}
+                {error.toLowerCase().includes("permission") && (
+                  <div className="max-w-6xl mx-auto mt-3 flex items-center gap-3">
+                    <p className="text-sm text-stone-700">You don’t have permission to manage workspace templates. You can still browse the built-in template library.</p>
+                    <button
+                      onClick={() => setPickerOpen(true)}
+                      className="ml-auto px-4 py-2 bg-white text-black rounded-lg shadow-sm"
+                    >
+                      Browse Built-ins
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* ── Filter bar ─────────────────────────────────────── */}
+            <div className="sticky top-0 z-10 bg-[var(--color-background)]/90 backdrop-blur-md border-b border-stone-200 px-8 py-3">
+              <div className="max-w-6xl mx-auto flex items-center gap-3 flex-wrap">
+                {/* Search */}
+                <div className="relative flex-1 min-w-48 max-w-xs">
+                  <svg
+                    className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                  </svg>
+                  <input
+                    type="search"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search templates…"
+                    className="w-full bg-white border border-stone-200 rounded-lg pl-9 pr-4 py-1.5
+                      text-sm text-stone-700 placeholder-stone-400 focus:outline-none focus:border-stone-300"
+                  />
+                </div>
+
+                {/* Category filter */}
+                <div className="flex gap-1.5 overflow-x-auto">
+                  <FilterChip
+                    active={activeCategory === "all"}
+                    onClick={() => setActiveCategory("all")}
+                    label="All"
+                  />
+                  {categories.map((cat) => (
+                    <FilterChip
+                      key={cat}
+                      active={activeCategory === cat}
+                      onClick={() => setActiveCategory(cat)}
+                      label={CATEGORY_META[cat]?.label ?? cat}
+                      icon={CATEGORY_META[cat]?.icon}
+                    />
+                  ))}
+                </div>
+
+                {/* Visibility filter */}
+                <select
+                  value={activeVisibility}
+                  onChange={(e) => setActiveVisibility(e.target.value as any)}
+                  className="bg-white border border-stone-200 rounded-lg px-3 py-1.5 text-sm text-stone-700
+                    focus:outline-none focus:border-stone-300"
+                >
+                  <option value="all">All visibility</option>
+                  <option value="workspace">Workspace</option>
+                  <option value="private">Private</option>
+                  <option value="public">Public</option>
+                </select>
+
+                {/* Sort */}
+                <select
+                  value={sortKey}
+                  onChange={(e) => setSortKey(e.target.value as SortKey)}
+                  className="bg-white border border-stone-200 rounded-lg px-3 py-1.5 text-sm text-stone-700
+                    focus:outline-none focus:border-stone-300"
+                >
+                  <option value="usage">Sort: Most Used</option>
+                  <option value="updated">Sort: Recently Updated</option>
+                  <option value="name">Sort: Name A–Z</option>
+                </select>
+
+                {/* View toggle */}
+                <div className="flex items-center border border-stone-200 rounded-lg overflow-hidden ml-auto">
+                  <ViewToggle active={viewMode === "grid"} onClick={() => setViewMode("grid")}>
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                        d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+                    </svg>
+                  </ViewToggle>
+                  <ViewToggle active={viewMode === "list"} onClick={() => setViewMode("list")}>
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                        d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+                    </svg>
+                  </ViewToggle>
+                </div>
+              </div>
+            </div>
+
+            {/* ── Content ────────────────────────────────────────── */}
+            <div className="px-8 py-6">
+              <div className="max-w-6xl mx-auto">
+                {loading ? (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {Array.from({ length: 6 }).map((_, i) => (
+                      <div key={i} className="h-44 bg-white/50 border border-stone-200 rounded-xl animate-pulse" />
+                    ))}
+                  </div>
+                ) : filtered.length === 0 ? (
+                  <EmptyState
+                      hasFilters={!!(search || activeCategory !== "all")}
+                      onClear={() => { setSearch(""); setActiveCategory("all"); }}
+                      onCreate={() => openEditor()}
+                      onSeed={handleSeed}
+                      seeding={seeding}
+                      onBrowse={() => setPickerOpen(true)}
+                      isAdmin={isAdmin}
+                    />
+                ) : (
+                  <div className="space-y-10">
+                    {/* Built-in section */}
+                    {builtInTemplates.length > 0 && (
+                      <section>
+                        <SectionHeader
+                          title="Built-in Templates"
+                          subtitle="Professional templates maintained by NoteNest"
+                          count={builtInTemplates.length}
+                          icon="⭐"
+                        />
+                        <TemplateGrid
+                          templates={builtInTemplates}
+                          viewMode={viewMode}
+                          onPreview={setPreviewTemplate}
+                          onEdit={openEditor}
+                          onDelete={setDeleteTarget}
+                          onCopy={handleCopy}
+                          onUse={(t) => {
+                            setPreviewTemplate(null);
+                            setPickerOpen(false);
+                            /* Open the picker for this specific template */
+                            setPickerOpen(true);
+                          }}
+                        />
+                      </section>
+                    )}
+
+                    {/* Custom section */}
+                    {customTemplates.length > 0 && (
+                      <section>
+                        <SectionHeader
+                          title="Custom Templates"
+                          subtitle="Templates created by your workspace members"
+                          count={customTemplates.length}
+                          icon="✏️"
+                        />
+                        <TemplateGrid
+                          templates={customTemplates}
+                          viewMode={viewMode}
+                          onPreview={setPreviewTemplate}
+                          onEdit={openEditor}
+                          onDelete={setDeleteTarget}
+                          onCopy={handleCopy}
+                          onUse={() => setPickerOpen(true)}
+                        />
+                      </section>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+
+      {/* ── Modals ─────────────────────────────────────────────── */}
+      <TemplateEditorModal
+        open={editorOpen}
+        workspaceId={workspaceId}
+        initial={editTarget}
+        onClose={() => { setEditorOpen(false); setEditTarget(null); }}
+        onSave={handleSave}
+      />
+
+      <TemplatePicker
+        open={pickerOpen}
+        workspaceId={workspaceId}
+        onClose={() => setPickerOpen(false)}
+        onApply={handleApplyFromPicker}
+      />
+
+      {/* Preview Drawer */}
+      {previewTemplate && (
+        <TemplatePreviewDrawer
+          template={previewTemplate}
+          onClose={() => setPreviewTemplate(null)}
+          onEdit={() => { openEditor(previewTemplate); setPreviewTemplate(null); }}
+          onCopy={() => { handleCopy(previewTemplate); setPreviewTemplate(null); }}
+          onUse={() => { setPreviewTemplate(null); setPickerOpen(true); }}
+        />
+      )}
+
+      {/* Delete confirm */}
+      {deleteTarget && (
+        <DeleteConfirmModal
+          template={deleteTarget}
+          onConfirm={() => handleDelete(deleteTarget)}
+          onCancel={() => setDeleteTarget(null)}
+        />
+      )}
+    </RouteGuard>
+  );
+}
+
+/* ── Sub-components ─────────────────────────────────────────────── */
+
+function TemplateGrid({
+  templates,
+  viewMode,
+  onPreview,
+  onEdit,
+  onDelete,
+  onCopy,
+  onUse,
+}: {
+  templates: Template[];
+  viewMode: ViewMode;
+  onPreview: (t: Template) => void;
+  onEdit: (t: Template) => void;
+  onDelete: (t: Template) => void;
+  onCopy: (t: Template) => void;
+  onUse: (t: Template) => void;
+}) {
+  if (viewMode === "list") {
+    return (
+      <div className="flex flex-col gap-2 mt-4">
+        {templates.map((t) => (
+          <TemplateCard
+            key={t._id}
+            template={t}
+            compact
+            onPreview={onPreview}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onCopy={onCopy}
+            onUse={onUse}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+      {templates.map((t) => (
+        <TemplateCard
+          key={t._id}
+          template={t}
+          onPreview={onPreview}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onCopy={onCopy}
+          onUse={onUse}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SectionHeader({
+  title,
+  subtitle,
+  count,
+  icon,
+}: {
+  title: string;
+  subtitle: string;
+  count: number;
+  icon: string;
+}) {
+  return (
+    <div className="flex items-center justify-between mb-1">
+      <div className="flex items-center gap-2">
+        <span className="text-lg">{icon}</span>
+        <div>
+          <h2 className="text-base font-semibold text-white flex items-center gap-2">
+            {title}
+            <span className="text-xs font-normal text-stone-500 bg-white/5 px-2 py-0.5 rounded-full">
+              {count}
+            </span>
+          </h2>
+          <p className="text-xs text-stone-500">{subtitle}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FilterChip({
+  active,
+  onClick,
+  label,
+  icon,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  icon?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium whitespace-nowrap transition-all
+        ${active
+          ? "bg-white text-black"
+          : "text-stone-700 border border-stone-200 hover:border-stone-300 hover:text-stone-900"
+        }`}
+    >
+      {icon && <span>{icon}</span>}
+      {label}
+    </button>
+  );
+}
+
+function ViewToggle({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`p-2 transition-colors ${active ? "bg-stone-200 text-stone-900" : "text-stone-600 hover:text-stone-700"}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function EmptyState({
+  hasFilters,
+  onClear,
+  onCreate,
+  onSeed,
+  seeding,
+  onBrowse,
+  isAdmin,
+}: {
+  hasFilters: boolean;
+  onClear: () => void;
+  onCreate: () => void;
+  onSeed: () => void;
+  seeding: boolean;
+  onBrowse?: () => void;
+  isAdmin?: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-stone-500">
+      <span className="text-6xl mb-4">📋</span>
+      <h3 className="text-lg font-semibold text-stone-300 mb-2">
+        {hasFilters ? "No matching templates" : "No templates yet"}
+      </h3>
+      <p className="text-sm text-center max-w-sm mb-6">
+        {hasFilters
+          ? "Try adjusting your search or filters."
+          : "Get started by adding the built-in professional templates or create your own custom template."}
+      </p>
+      <div className="flex gap-3">
+        {hasFilters ? (
+          <button
+            onClick={onClear}
+            className="px-4 py-2 text-sm font-medium text-stone-700 border border-stone-200 rounded-lg hover:bg-stone-100 transition-colors"
+          >
+            Clear filters
+          </button>
+        ) : (
+          <>
+            <button
+              onClick={onBrowse}
+              className="px-4 py-2 text-sm font-medium text-stone-700 border border-stone-200 rounded-lg hover:bg-stone-100 transition-colors"
+            >
+              Browse Built-ins
+            </button>
+
+            {isAdmin ? (
+              <button
+                onClick={onSeed}
+                disabled={seeding}
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-white text-black rounded-lg hover:bg-stone-200 disabled:opacity-50 transition-colors"
+              >
+                {seeding ? "Adding…" : "Sync Built-ins"}
+              </button>
+            ) : (
+              <button
+                onClick={onCreate}
+                className="px-4 py-2 text-sm font-medium bg-white text-black rounded-lg hover:bg-stone-200 transition-colors"
+              >
+                Create Template
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Preview Drawer ─────────────────────────────────────────────── */
+function TemplatePreviewDrawer({
+  template,
+  onClose,
+  onEdit,
+  onCopy,
+  onUse,
+}: {
+  template: Template;
+  onClose: () => void;
+  onEdit: () => void;
+  onCopy: () => void;
+  onUse: () => void;
+}) {
+  const meta = CATEGORY_META[template.category] ?? CATEGORY_META.general;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <aside
+        className="fixed right-0 top-0 bottom-0 z-50 w-full max-w-xl bg-[#111113] border-l border-[#222224]
+          flex flex-col shadow-2xl overflow-hidden"
+        role="complementary"
+        aria-label="Template preview"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[#222224]">
+          <div className="flex items-center gap-3 min-w-0">
+            <span className="text-2xl shrink-0">{meta.icon}</span>
+            <div className="min-w-0">
+              <h2 className="font-semibold text-white truncate">{template.title}</h2>
+              <div className="flex items-center gap-2 mt-0.5">
+                <span className={`text-[10px] px-2 py-0.5 rounded-full border ${meta.color}`}>{meta.label}</span>
+                {template.isBuiltIn && (
+                  <span className="text-[10px] text-amber-400/80 font-medium">Built-in</span>
+                )}
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg text-stone-400 hover:text-white hover:bg-white/5 transition-colors shrink-0"
+            aria-label="Close preview"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Meta pills */}
+        <div className="px-6 py-3 flex items-center gap-3 flex-wrap border-b border-[#1a1a1d]">
+          <MetaPill icon="🔄" label={`${template.usageCount} uses`} />
+          <MetaPill icon="📌" label={`v${template.version}`} />
+          <MetaPill icon="🔒" label={template.visibility} />
+          {template.placeholders?.length > 0 && (
+            <MetaPill icon="🏷️" label={`${template.placeholders.length} variable${template.placeholders.length !== 1 ? "s" : ""}`} />
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          {/* Description */}
+          {template.description && (
+            <div>
+              <h3 className="text-xs font-medium text-stone-500 uppercase tracking-wider mb-2">About</h3>
+              <p className="text-sm text-stone-300 leading-relaxed">{template.description}</p>
+            </div>
+          )}
+
+          {/* Tags */}
+          {template.tags && template.tags.length > 0 && (
+            <div>
+              <h3 className="text-xs font-medium text-stone-500 uppercase tracking-wider mb-2">Tags</h3>
+              <div className="flex flex-wrap gap-1.5">
+                {template.tags.map((tag) => (
+                  <span key={tag} className="px-2 py-0.5 text-xs rounded-full bg-white/5 text-stone-400 border border-white/5">
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Variables */}
+          {template.placeholders && template.placeholders.length > 0 && (
+            <div>
+              <h3 className="text-xs font-medium text-stone-500 uppercase tracking-wider mb-2">Variables</h3>
+              <div className="flex flex-col gap-2">
+                {template.placeholders.map((p) => (
+                  <div key={p.name} className="flex items-center justify-between p-3 bg-[#0c0c0e] border border-[#1a1a1d] rounded-lg">
+                    <div>
+                      <span className="text-xs font-mono text-amber-400">{`{{${p.name}}}`}</span>
+                      <span className="text-xs text-stone-400 ml-2">{p.label}</span>
+                      {p.description && <p className="text-[11px] text-stone-500 mt-0.5">{p.description}</p>}
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <span className="text-[10px] text-stone-500 bg-white/5 px-1.5 py-0.5 rounded">{p.type}</span>
+                      {p.required && <span className="text-[10px] text-red-400">required</span>}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Body preview */}
+          <div>
+            <h3 className="text-xs font-medium text-stone-500 uppercase tracking-wider mb-2">Template Content</h3>
+            <div className="bg-[#0c0c0e] border border-[#1a1a1d] rounded-xl p-4">
+              <pre className="text-xs text-stone-400 font-mono leading-relaxed whitespace-pre-wrap overflow-x-auto">
+                {template.body}
+              </pre>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer actions */}
+        <div className="flex items-center gap-3 px-6 py-4 border-t border-[#222224] bg-[#0d0d0f]">
+          <button
+            onClick={onCopy}
+            className="flex items-center gap-2 px-4 py-2 text-sm text-stone-400 border border-[#2a2a2d]
+              rounded-lg hover:text-white hover:border-[#333336] transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+            Duplicate
+          </button>
+          {!template.isBuiltIn && (
+            <button
+              onClick={onEdit}
+              className="flex items-center gap-2 px-4 py-2 text-sm text-stone-400 border border-[#2a2a2d]
+                rounded-lg hover:text-white hover:border-[#333336] transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+              Edit
+            </button>
+          )}
+          <button
+            onClick={onUse}
+            className="flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium bg-white text-black
+              rounded-lg hover:bg-stone-200 transition-colors"
+          >
+            Use this template
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+      </aside>
+    </>
+  );
+}
+
+/* ── Delete Confirm Modal ─────────────────────────────────────── */
+function DeleteConfirmModal({
+  template,
+  onConfirm,
+  onCancel,
+}: {
+  template: Template;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
+      <div className="w-full max-w-sm bg-[#111113] border border-[#2a2a2d] rounded-2xl p-6 shadow-2xl">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center shrink-0">
+            <svg className="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <div>
+            <h3 className="font-semibold text-white">Delete Template</h3>
+            <p className="text-sm text-stone-400">This action cannot be undone.</p>
+          </div>
+        </div>
+        <p className="text-sm text-stone-300 mb-5">
+          Are you sure you want to delete <strong className="text-white">"{template.title}"</strong>?
+        </p>
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 px-4 py-2 text-sm text-stone-400 border border-[#2a2a2d] rounded-lg hover:text-white hover:border-[#333336] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 px-4 py-2 text-sm font-medium bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MetaPill({ icon, label }: { icon: string; label: string }) {
+  return (
+    <span className="flex items-center gap-1 text-[11px] text-stone-500 bg-white/[0.04] px-2 py-1 rounded-full border border-white/[0.05]">
+      <span>{icon}</span>
+      {label}
+    </span>
+  );
+}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -109,6 +109,33 @@ export default function Sidebar() {
           {collapsed && <span className="text-sm">N</span>}
         </Link>
 
+        <Link
+          href={`/workspace/${activeWorkspace.id}/templates`}
+          className={`${linkBase} flex items-center ${
+            collapsed ? "justify-center" : "gap-2"
+          } ${
+            pathname === `/workspace/${activeWorkspace.id}/templates`
+              ? activeClass
+              : ""
+          }`}
+        >
+          <svg
+            className="w-4 h-4 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            />
+          </svg>
+          {!collapsed && "Templates"}
+          {collapsed && <span className="text-sm">T</span>}
+        </Link>
+
         {canAccessManagement && (
           <Link
             href="/management"

--- a/frontend/components/TemplateCard.tsx
+++ b/frontend/components/TemplateCard.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import type { Template, TemplateCategory } from "@/lib/api";
+
+/* ── Category metadata ─────────────────────────────────────────── */
+export const CATEGORY_META: Record<
+  TemplateCategory,
+  { label: string; icon: string; color: string }
+> = {
+  meeting: {
+    label: "Meeting",
+    icon: "👥",
+    color: "bg-blue-500/10 text-blue-400 border-blue-500/20",
+  },
+  rfc: {
+    label: "RFC",
+    icon: "📐",
+    color: "bg-violet-500/10 text-violet-400 border-violet-500/20",
+  },
+  design: {
+    label: "Design",
+    icon: "🎨",
+    color: "bg-pink-500/10 text-pink-400 border-pink-500/20",
+  },
+  project: {
+    label: "Project",
+    icon: "🗂️",
+    color: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+  },
+  bug_report: {
+    label: "Bug Report",
+    icon: "🐛",
+    color: "bg-red-500/10 text-red-400 border-red-500/20",
+  },
+  retrospective: {
+    label: "Retrospective",
+    icon: "🔄",
+    color: "bg-teal-500/10 text-teal-400 border-teal-500/20",
+  },
+  onboarding: {
+    label: "Onboarding",
+    icon: "🚀",
+    color: "bg-green-500/10 text-green-400 border-green-500/20",
+  },
+  research: {
+    label: "Research",
+    icon: "🔬",
+    color: "bg-cyan-500/10 text-cyan-400 border-cyan-500/20",
+  },
+  sprint: {
+    label: "Sprint",
+    icon: "⚡",
+    color: "bg-orange-500/10 text-orange-400 border-orange-500/20",
+  },
+  general: {
+    label: "General",
+    icon: "📄",
+    color: "bg-stone-500/10 text-stone-400 border-stone-500/20",
+  },
+};
+
+interface TemplateCardProps {
+  template: Template;
+  onPreview?: (template: Template) => void;
+  onEdit?: (template: Template) => void;
+  onDelete?: (template: Template) => void;
+  onCopy?: (template: Template) => void;
+  onUse?: (template: Template) => void;
+  showActions?: boolean;
+  compact?: boolean;
+}
+
+export default function TemplateCard({
+  template,
+  onPreview,
+  onEdit,
+  onDelete,
+  onCopy,
+  onUse,
+  showActions = true,
+  compact = false,
+}: TemplateCardProps) {
+  const meta = CATEGORY_META[template.category] ?? CATEGORY_META.general;
+
+  return (
+    <article
+      className={`group relative flex flex-col bg-[#111113] border border-[#222224] rounded-xl overflow-hidden
+        hover:border-[#333336] hover:shadow-lg hover:shadow-black/30
+        transition-all duration-200 cursor-pointer
+        ${compact ? "p-4 gap-3" : "p-5 gap-4"}`}
+      onClick={() => onPreview?.(template)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => e.key === "Enter" && onPreview?.(template)}
+      aria-label={`Template: ${template.title}`}
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-xl shrink-0" aria-hidden>
+            {meta.icon}
+          </span>
+          <div className="min-w-0">
+            <h3
+              className={`font-semibold text-white leading-tight truncate
+                ${compact ? "text-sm" : "text-base"}`}
+            >
+              {template.title}
+            </h3>
+            {template.isBuiltIn && (
+              <span className="text-[10px] font-medium text-amber-400/80 uppercase tracking-wider">
+                Built-in
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Actions (hover) */}
+        {showActions && (
+          <div
+            className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {onCopy && (
+              <ActionButton
+                title="Duplicate"
+                onClick={() => onCopy(template)}
+                icon={
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                  </svg>
+                }
+              />
+            )}
+            {onEdit && !template.isBuiltIn && (
+              <ActionButton
+                title="Edit"
+                onClick={() => onEdit(template)}
+                icon={
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                }
+              />
+            )}
+            {onDelete && !template.isBuiltIn && (
+              <ActionButton
+                title="Delete"
+                onClick={() => onDelete(template)}
+                icon={
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                }
+                danger
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Category badge */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <span
+          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border
+            ${meta.color}`}
+        >
+          {meta.label}
+        </span>
+        {template.tags.slice(0, compact ? 2 : 3).map((tag) => (
+          <span
+            key={tag}
+            className="px-2 py-0.5 rounded-full text-[11px] bg-white/5 text-stone-400 border border-white/5"
+          >
+            #{tag}
+          </span>
+        ))}
+        {template.tags.length > (compact ? 2 : 3) && (
+          <span className="text-[11px] text-stone-500">
+            +{template.tags.length - (compact ? 2 : 3)}
+          </span>
+        )}
+      </div>
+
+      {/* Description */}
+      {!compact && (
+        <p className="text-sm text-stone-400 leading-relaxed line-clamp-2 flex-1">
+          {template.description}
+        </p>
+      )}
+
+      {/* Footer */}
+      <div className="flex items-center justify-between pt-1 border-t border-white/[0.05]">
+        <div className="flex items-center gap-3 text-[11px] text-stone-500">
+          <span className="flex items-center gap-1">
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            </svg>
+            {template.usageCount} uses
+          </span>
+          <span>v{template.version}</span>
+          <span className="capitalize">{template.visibility}</span>
+        </div>
+
+        {onUse && (
+          <button
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium
+              bg-white text-black hover:bg-stone-200
+              transition-colors duration-150 shrink-0"
+            onClick={(e) => {
+              e.stopPropagation();
+              onUse(template);
+            }}
+          >
+            Use template
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </article>
+  );
+}
+
+/* ── Small icon button ─────────────────────────────────────────── */
+function ActionButton({
+  icon,
+  title,
+  onClick,
+  danger = false,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  onClick: () => void;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      title={title}
+      aria-label={title}
+      onClick={onClick}
+      className={`p-1.5 rounded-md transition-colors duration-150
+        ${danger
+          ? "text-stone-500 hover:text-red-400 hover:bg-red-500/10"
+          : "text-stone-500 hover:text-stone-300 hover:bg-white/5"
+        }`}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/frontend/components/TemplateEditorModal.tsx
+++ b/frontend/components/TemplateEditorModal.tsx
@@ -1,0 +1,552 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import type { Template, TemplateCategory, TemplateVisibility, TemplatePlaceholder } from "@/lib/api";
+import { CATEGORY_META } from "./TemplateCard";
+
+interface TemplateEditorModalProps {
+  open: boolean;
+  workspaceId: string;
+  initial?: Template | null;
+  onClose: () => void;
+  onSave: (data: Partial<Template>) => Promise<void>;
+}
+
+const VISIBILITY_OPTIONS: { value: TemplateVisibility; label: string; description: string }[] = [
+  { value: "workspace", label: "Workspace", description: "Visible to all workspace members" },
+  { value: "private", label: "Private", description: "Only visible to you" },
+  { value: "public", label: "Public", description: "Visible to anyone with the link" },
+];
+
+const PLACEHOLDER_TYPES: TemplatePlaceholder["type"][] = ["text", "date", "list", "number"];
+
+const CATEGORY_LIST = Object.entries(CATEGORY_META) as [TemplateCategory, typeof CATEGORY_META[TemplateCategory]][];
+
+export default function TemplateEditorModal({
+  open,
+  initial,
+  onClose,
+  onSave,
+}: TemplateEditorModalProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState<TemplateCategory>("general");
+  const [visibility, setVisibility] = useState<TemplateVisibility>("workspace");
+  const [tags, setTags] = useState("");
+  const [body, setBody] = useState("");
+  const [placeholders, setPlaceholders] = useState<TemplatePlaceholder[]>([]);
+  const [tab, setTab] = useState<"editor" | "preview" | "placeholders">("editor");
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+
+  /* Populate fields when editing */
+  useEffect(() => {
+    if (!open) return;
+    if (initial) {
+      setTitle(initial.title);
+      setDescription(initial.description);
+      setCategory(initial.category);
+      setVisibility(initial.visibility);
+      setTags(initial.tags.join(", "));
+      setBody(initial.body);
+      setPlaceholders(initial.placeholders ? [...initial.placeholders] : []);
+    } else {
+      setTitle("");
+      setDescription("");
+      setCategory("general");
+      setVisibility("workspace");
+      setTags("");
+      setBody(DEFAULT_BODY);
+      setPlaceholders([]);
+    }
+    setErrors({});
+    setTab("editor");
+  }, [open, initial]);
+
+  function validate() {
+    const e: Record<string, string> = {};
+    if (!title.trim()) e.title = "Title is required.";
+    if (!body.trim()) e.body = "Template body is required.";
+    if (description.length > 500) e.description = "Max 500 characters.";
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  }
+
+  async function handleSave() {
+    if (!validate()) return;
+    setSaving(true);
+    try {
+      await onSave({
+        title: title.trim(),
+        description: description.trim(),
+        category,
+        visibility,
+        tags: tags
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+        body,
+        placeholders,
+      });
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  /* Insert placeholder syntax into body at cursor */
+  function insertPlaceholder(name: string) {
+    const ta = bodyRef.current;
+    if (!ta) return;
+    const start = ta.selectionStart;
+    const end = ta.selectionEnd;
+    const before = body.slice(0, start);
+    const after = body.slice(end);
+    const inserted = `{{${name}}}`;
+    setBody(before + inserted + after);
+    setTimeout(() => {
+      ta.focus();
+      ta.setSelectionRange(start + inserted.length, start + inserted.length);
+    }, 0);
+  }
+
+  function addPlaceholder() {
+    setPlaceholders((prev) => [
+      ...prev,
+      { name: "", label: "", type: "text", defaultValue: "", description: "", required: false },
+    ]);
+  }
+
+  function updatePlaceholder(index: number, field: keyof TemplatePlaceholder, value: any) {
+    setPlaceholders((prev) =>
+      prev.map((p, i) => (i === index ? { ...p, [field]: value } : p))
+    );
+  }
+
+  function removePlaceholder(index: number) {
+    setPlaceholders((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  /* Rendered preview (simple markdown-like treatment for display) */
+  const previewBody = (() => {
+    let rendered = body;
+    placeholders.forEach((p) => {
+      const regex = new RegExp(`\\{\\{\\s*${p.name}\\s*\\}\\}`, "g");
+      rendered = rendered.replace(regex, `<span class="bg-amber-400/20 text-amber-300 px-1 rounded text-xs">${p.defaultValue || p.label || p.name}</span>`);
+    });
+    return rendered;
+  })();
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={initial ? "Edit Template" : "Create Template"}
+    >
+      <div
+        className="relative w-full max-w-4xl max-h-[90vh] flex flex-col bg-[#111113] border border-[#222224] rounded-2xl shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <header className="flex items-center justify-between px-6 py-4 border-b border-[#222224] shrink-0">
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              {initial ? "Edit Template" : "Create Template"}
+            </h2>
+            <p className="text-sm text-stone-400 mt-0.5">
+              {initial ? `Editing v${initial.version}` : "Design a reusable note template for your workspace"}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg text-stone-400 hover:text-white hover:bg-white/5 transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </header>
+
+        {/* Body — split layout */}
+        <div className="flex flex-1 min-h-0">
+          {/* Left panel: metadata */}
+          <aside className="w-72 shrink-0 flex flex-col gap-5 p-5 border-r border-[#222224] overflow-y-auto">
+            {/* Title */}
+            <Field label="Title" error={errors.title} required>
+              <input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="e.g. Weekly Standup Notes"
+                className={INPUT_CLS}
+                maxLength={120}
+              />
+            </Field>
+
+            {/* Description */}
+            <Field label="Description" error={errors.description}>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Describe when and how to use this template…"
+                rows={3}
+                className={`${INPUT_CLS} resize-none`}
+                maxLength={500}
+              />
+              <p className="text-[10px] text-stone-600 mt-1 text-right">
+                {description.length}/500
+              </p>
+            </Field>
+
+            {/* Category */}
+            <Field label="Category">
+              <div className="grid grid-cols-2 gap-1.5">
+                {CATEGORY_LIST.map(([key, meta]) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setCategory(key)}
+                    className={`flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-xs font-medium border transition-all
+                      ${
+                        category === key
+                          ? "border-white/20 bg-white/10 text-white"
+                          : "border-transparent bg-white/[0.03] text-stone-400 hover:bg-white/[0.06]"
+                      }`}
+                  >
+                    <span>{meta.icon}</span>
+                    {meta.label}
+                  </button>
+                ))}
+              </div>
+            </Field>
+
+            {/* Tags */}
+            <Field label="Tags">
+              <input
+                value={tags}
+                onChange={(e) => setTags(e.target.value)}
+                placeholder="meeting, agile, engineering"
+                className={INPUT_CLS}
+              />
+              <p className="text-[10px] text-stone-600 mt-1">Comma-separated</p>
+            </Field>
+
+            {/* Visibility */}
+            <Field label="Visibility">
+              <div className="flex flex-col gap-1.5">
+                {VISIBILITY_OPTIONS.map((opt) => (
+                  <label
+                    key={opt.value}
+                    className={`flex items-start gap-2.5 p-2.5 rounded-lg border cursor-pointer transition-all
+                      ${
+                        visibility === opt.value
+                          ? "border-white/20 bg-white/[0.06]"
+                          : "border-transparent bg-white/[0.02] hover:bg-white/[0.04]"
+                      }`}
+                  >
+                    <input
+                      type="radio"
+                      name="visibility"
+                      value={opt.value}
+                      checked={visibility === opt.value}
+                      onChange={() => setVisibility(opt.value)}
+                      className="mt-0.5 accent-white"
+                    />
+                    <div>
+                      <div className="text-xs font-medium text-white">{opt.label}</div>
+                      <div className="text-[10px] text-stone-500 mt-0.5">{opt.description}</div>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </Field>
+          </aside>
+
+          {/* Right panel: body editor / preview / placeholders */}
+          <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+            {/* Tabs */}
+            <div className="flex items-center gap-1 px-5 pt-4 pb-0 border-b border-[#222224]">
+              {(["editor", "placeholders", "preview"] as const).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setTab(t)}
+                  className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-colors capitalize
+                    ${
+                      tab === t
+                        ? "bg-[#1a1a1d] text-white border border-b-0 border-[#333336]"
+                        : "text-stone-500 hover:text-stone-300"
+                    }`}
+                >
+                  {t === "placeholders" ? `Variables (${placeholders.length})` : t}
+                </button>
+              ))}
+            </div>
+
+            {/* Tab content */}
+            <div className="flex-1 overflow-y-auto p-5">
+              {tab === "editor" && (
+                <div className="flex flex-col gap-2 h-full">
+                  {errors.body && (
+                    <p className="text-xs text-red-400">{errors.body}</p>
+                  )}
+                  {/* Quick-insert placeholders */}
+                  {placeholders.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5 mb-1">
+                      <span className="text-[11px] text-stone-500 self-center">Insert:</span>
+                      {placeholders.filter((p) => p.name).map((p) => (
+                        <button
+                          key={p.name}
+                          type="button"
+                          onClick={() => insertPlaceholder(p.name)}
+                          className="px-2 py-0.5 text-[11px] rounded-full bg-amber-400/10 text-amber-300 border border-amber-400/20 hover:bg-amber-400/20 transition-colors"
+                        >
+                          {`{{${p.name}}}`}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  <textarea
+                    ref={bodyRef}
+                    value={body}
+                    onChange={(e) => setBody(e.target.value)}
+                    placeholder="Write your Markdown template here. Use {{placeholder_name}} for dynamic fields."
+                    className="flex-1 w-full min-h-[340px] bg-[#0c0c0e] border border-[#222224] rounded-xl p-4
+                      text-sm text-stone-200 font-mono placeholder-stone-600 leading-relaxed
+                      focus:outline-none focus:border-stone-500 resize-none"
+                    spellCheck={false}
+                  />
+                  <p className="text-[10px] text-stone-600">
+                    Markdown supported · Use {`{{variable}}`} for dynamic placeholders
+                  </p>
+                </div>
+              )}
+
+              {tab === "placeholders" && (
+                <div className="flex flex-col gap-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="text-sm font-medium text-white">Template Variables</h3>
+                      <p className="text-xs text-stone-400 mt-0.5">
+                        Define variables that will be filled in when using this template.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={addPlaceholder}
+                      className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-white/10 text-white rounded-lg hover:bg-white/15 transition-colors"
+                    >
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                      </svg>
+                      Add Variable
+                    </button>
+                  </div>
+
+                  {placeholders.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-12 text-stone-500">
+                      <svg className="w-10 h-10 mb-3 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                          d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+                      </svg>
+                      <p className="text-sm">No variables defined yet</p>
+                      <p className="text-xs mt-1">Variables let users fill in custom values when applying the template.</p>
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-3">
+                      {placeholders.map((p, i) => (
+                        <div key={i} className="bg-[#0c0c0e] border border-[#222224] rounded-xl p-4">
+                          <div className="flex items-center justify-between mb-3">
+                            <span className="text-xs font-medium text-stone-300">Variable #{i + 1}</span>
+                            <button
+                              type="button"
+                              onClick={() => removePlaceholder(i)}
+                              className="text-stone-500 hover:text-red-400 transition-colors"
+                            >
+                              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                              </svg>
+                            </button>
+                          </div>
+                          <div className="grid grid-cols-2 gap-3">
+                            <Field label="Name (key)">
+                              <input
+                                value={p.name}
+                                onChange={(e) =>
+                                  updatePlaceholder(i, "name",
+                                    e.target.value.replace(/\s+/g, "_").toLowerCase()
+                                  )
+                                }
+                                placeholder="e.g. date"
+                                className={INPUT_CLS}
+                              />
+                            </Field>
+                            <Field label="Display Label">
+                              <input
+                                value={p.label}
+                                onChange={(e) => updatePlaceholder(i, "label", e.target.value)}
+                                placeholder="e.g. Meeting Date"
+                                className={INPUT_CLS}
+                              />
+                            </Field>
+                            <Field label="Type">
+                              <select
+                                value={p.type}
+                                onChange={(e) => updatePlaceholder(i, "type", e.target.value)}
+                                className={INPUT_CLS}
+                              >
+                                {PLACEHOLDER_TYPES.map((t) => (
+                                  <option key={t} value={t}>
+                                    {t.charAt(0).toUpperCase() + t.slice(1)}
+                                  </option>
+                                ))}
+                              </select>
+                            </Field>
+                            <Field label="Default Value">
+                              <input
+                                value={p.defaultValue || ""}
+                                onChange={(e) => updatePlaceholder(i, "defaultValue", e.target.value)}
+                                placeholder="Optional default"
+                                className={INPUT_CLS}
+                              />
+                            </Field>
+                            <div className="col-span-2">
+                              <Field label="Description">
+                                <input
+                                  value={p.description || ""}
+                                  onChange={(e) => updatePlaceholder(i, "description", e.target.value)}
+                                  placeholder="Helper text shown to users"
+                                  className={INPUT_CLS}
+                                />
+                              </Field>
+                            </div>
+                            <div className="col-span-2">
+                              <label className="flex items-center gap-2 cursor-pointer">
+                                <input
+                                  type="checkbox"
+                                  checked={p.required}
+                                  onChange={(e) => updatePlaceholder(i, "required", e.target.checked)}
+                                  className="w-3.5 h-3.5 accent-white"
+                                />
+                                <span className="text-xs text-stone-400">Required field</span>
+                              </label>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {tab === "preview" && (
+                <div className="prose prose-invert prose-sm max-w-none">
+                  <div className="bg-[#0c0c0e] border border-[#222224] rounded-xl p-6">
+                    <div
+                      className="text-stone-300 text-sm leading-relaxed whitespace-pre-wrap font-mono"
+                      dangerouslySetInnerHTML={{ __html: previewBody }}
+                    />
+                  </div>
+                  <p className="text-[11px] text-stone-600 mt-3">
+                    Variables shown with sample / default values.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <footer className="flex items-center justify-between px-6 py-4 border-t border-[#222224] shrink-0 bg-[#0d0d0f]">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-stone-400 hover:text-white transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="flex items-center gap-2 px-5 py-2 text-sm font-medium bg-white text-black rounded-lg
+              hover:bg-stone-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? (
+              <>
+                <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Saving…
+              </>
+            ) : (
+              <>
+                {initial ? "Save Changes" : "Create Template"}
+              </>
+            )}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+/* ── Helpers ──────────────────────────────────────────────────── */
+const INPUT_CLS =
+  "w-full bg-[#0c0c0e] border border-[#222224] rounded-lg px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-stone-500 transition-colors";
+
+function Field({
+  label,
+  children,
+  error,
+  required,
+}: {
+  label: string;
+  children: React.ReactNode;
+  error?: string;
+  required?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-xs font-medium text-stone-400">
+        {label}
+        {required && <span className="text-red-400 ml-0.5">*</span>}
+      </label>
+      {children}
+      {error && <p className="text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}
+
+const DEFAULT_BODY = `# {{title}}
+
+**Date:** {{date}}
+**Author:** 
+
+---
+
+## Overview
+
+_Brief description of the purpose of this note._
+
+---
+
+## Details
+
+
+
+---
+
+## Action Items
+
+- [ ] 
+- [ ] 
+
+---
+
+## References
+
+- 
+`;

--- a/frontend/components/TemplatePicker.tsx
+++ b/frontend/components/TemplatePicker.tsx
@@ -1,0 +1,457 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import type { Template, TemplateCategory, TemplatePlaceholder } from "@/lib/api";
+import { CATEGORY_META } from "./TemplateCard";
+import { apiService } from "@/lib/api";
+
+interface TemplatePickerProps {
+  open: boolean;
+  workspaceId: string;
+  onClose: () => void;
+  /** Called when the user confirms. Returns the fully-rendered body string. */
+  onApply: (title: string, body: string) => void;
+}
+
+type Step = "browse" | "fill";
+
+export default function TemplatePicker({
+  open,
+  workspaceId,
+  onClose,
+  onApply,
+}: TemplatePickerProps) {
+  /* ── State ───────────────────────────────────────────────────── */
+  const [step, setStep] = useState<Step>("browse");
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [activeCategory, setActiveCategory] = useState<TemplateCategory | "all">("all");
+  const [selected, setSelected] = useState<Template | null>(null);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState("");
+
+  /* ── Load templates ─────────────────────────────────────────── */
+  useEffect(() => {
+    if (!open || !workspaceId) return;
+    setLoading(true);
+    setStep("browse");
+    setSelected(null);
+    setSearch("");
+    setActiveCategory("all");
+
+    // Try to load workspace templates first. If none found or access denied,
+    // fall back to the global built-in templates so users can still browse/apply.
+    (async () => {
+      try {
+        const res = await apiService.getWorkspaceTemplates(workspaceId);
+        const workTemplates = res.templates || [];
+        if (workTemplates.length > 0) {
+          setTemplates(workTemplates);
+        } else {
+          // No workspace templates yet — show built-ins for browsing
+          const builtin = await apiService.getBuiltInTemplates();
+          setTemplates(builtin.templates || []);
+        }
+      } catch (err: any) {
+        // If workspace access is denied (e.g., not a member) or other error,
+        // still attempt to show built-in templates so users can preview/apply.
+        try {
+          const builtin = await apiService.getBuiltInTemplates();
+          setTemplates(builtin.templates || []);
+        } catch (_) {
+          setTemplates([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [open, workspaceId]);
+
+  /* ── Filtered list ──────────────────────────────────────────── */
+  const filtered = useMemo(() => {
+    return templates.filter((t) => {
+      const matchCat = activeCategory === "all" || t.category === activeCategory;
+      const q = search.toLowerCase();
+      const matchSearch =
+        !q ||
+        t.title.toLowerCase().includes(q) ||
+        t.description.toLowerCase().includes(q) ||
+        t.tags.some((tag) => tag.toLowerCase().includes(q));
+      return matchCat && matchSearch;
+    });
+  }, [templates, activeCategory, search]);
+
+  /* ── Unique categories in current list ─────────────────────── */
+  const categories = useMemo(() => {
+    const cats = new Set(templates.map((t) => t.category));
+    return Array.from(cats);
+  }, [templates]);
+
+  /* ── Select & advance to fill step ─────────────────────────── */
+  function selectTemplate(tpl: Template) {
+    setSelected(tpl);
+    // Pre-populate default values
+    const defaults: Record<string, string> = {};
+    tpl.placeholders?.forEach((p) => {
+      defaults[p.name] = p.type === "date"
+        ? new Date().toLocaleDateString("en-CA") // YYYY-MM-DD
+        : p.defaultValue || "";
+    });
+    setValues(defaults);
+    setError("");
+    setStep("fill");
+  }
+
+  /* ── Apply template ─────────────────────────────────────────── */
+  async function handleApply() {
+    if (!selected) return;
+
+    // Validate required
+    const missing = selected.placeholders?.filter(
+      (p) => p.required && !values[p.name]?.trim()
+    );
+    if (missing && missing.length > 0) {
+      setError(`Please fill in: ${missing.map((p) => p.label || p.name).join(", ")}`);
+      return;
+    }
+
+    setApplying(true);
+    setError("");
+    try {
+      const res = await apiService.useTemplate(selected._id, values);
+      onApply(res.title, res.body);
+    } catch {
+      setError("Failed to apply template. Please try again.");
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Choose a template"
+    >
+      <div
+        className="relative w-full max-w-3xl max-h-[85vh] flex flex-col bg-[#111113] border border-[#222224] rounded-2xl shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <header className="flex items-center justify-between px-6 py-4 border-b border-[#222224] shrink-0">
+          <div className="flex items-center gap-3">
+            {step === "fill" && (
+              <button
+                onClick={() => setStep("browse")}
+                className="p-1.5 rounded-lg text-stone-400 hover:text-white hover:bg-white/5 transition-colors"
+                aria-label="Back"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+            )}
+            <div>
+              <h2 className="text-base font-semibold text-white">
+                {step === "browse" ? "Choose a Template" : `Use: ${selected?.title}`}
+              </h2>
+              <p className="text-xs text-stone-400 mt-0.5">
+                {step === "browse"
+                  ? `${filtered.length} template${filtered.length !== 1 ? "s" : ""} available`
+                  : "Fill in the variables below to customise your note."}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg text-stone-400 hover:text-white hover:bg-white/5 transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </header>
+
+        {/* ── BROWSE STEP ───────────────────────────────────────── */}
+        {step === "browse" && (
+          <div className="flex flex-col min-h-0 flex-1">
+            {/* Search + filters */}
+            <div className="flex flex-col gap-3 px-5 py-4 border-b border-[#1a1a1d]">
+              <div className="relative">
+                <svg
+                  className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+                <input
+                  type="search"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search templates…"
+                  className="w-full bg-[#0c0c0e] border border-[#222224] rounded-xl pl-9 pr-4 py-2
+                    text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-stone-500"
+                />
+              </div>
+
+              {/* Category chips */}
+              <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
+                <CategoryChip
+                  active={activeCategory === "all"}
+                  onClick={() => setActiveCategory("all")}
+                  label="All"
+                  icon="🗂️"
+                />
+                {categories.map((cat) => {
+                  const meta = CATEGORY_META[cat] ?? CATEGORY_META.general;
+                  return (
+                    <CategoryChip
+                      key={cat}
+                      active={activeCategory === cat}
+                      onClick={() => setActiveCategory(cat)}
+                      label={meta.label}
+                      icon={meta.icon}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Template grid */}
+            <div className="flex-1 overflow-y-auto px-5 py-4">
+              {loading ? (
+                <div className="flex items-center justify-center py-20 text-stone-500">
+                  <svg className="w-6 h-6 animate-spin mr-2" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  Loading templates…
+                </div>
+              ) : filtered.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-20 text-stone-500">
+                  <span className="text-5xl mb-3">🔍</span>
+                  <p className="text-sm font-medium">No templates found</p>
+                  <p className="text-xs mt-1">Try different search terms or category</p>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {filtered.map((tpl) => {
+                    const meta = CATEGORY_META[tpl.category] ?? CATEGORY_META.general;
+                    return (
+                      <button
+                        key={tpl._id}
+                        type="button"
+                        onClick={() => selectTemplate(tpl)}
+                        className="text-left bg-[#0c0c0e] border border-[#222224] rounded-xl p-4 
+                          hover:border-[#333336] hover:bg-[#141416] transition-all duration-150 group"
+                      >
+                        <div className="flex items-start gap-3 mb-2">
+                          <span className="text-2xl shrink-0">{meta.icon}</span>
+                          <div className="min-w-0">
+                            <h4 className="text-sm font-semibold text-white truncate">{tpl.title}</h4>
+                            <span className={`inline-block mt-0.5 text-[10px] px-2 py-0.5 rounded-full border ${meta.color}`}>
+                              {meta.label}
+                            </span>
+                          </div>
+                        </div>
+                        <p className="text-xs text-stone-400 leading-relaxed line-clamp-2 mb-3">
+                          {tpl.description}
+                        </p>
+                        <div className="flex items-center justify-between text-[10px] text-stone-600">
+                          <span>{tpl.placeholders?.length || 0} variable{tpl.placeholders?.length !== 1 ? "s" : ""}</span>
+                          <span className="flex items-center gap-1 opacity-0 group-hover:opacity-100 text-white transition-opacity">
+                            Use this <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* ── FILL STEP ─────────────────────────────────────────── */}
+        {step === "fill" && selected && (
+          <div className="flex flex-1 min-h-0">
+            {/* Left: form */}
+            <div className="flex-1 flex flex-col p-5 gap-4 overflow-y-auto">
+              {selected.placeholders && selected.placeholders.length > 0 ? (
+                <>
+                  {selected.placeholders.map((p: TemplatePlaceholder) => (
+                    <PlaceholderField
+                      key={p.name}
+                      placeholder={p}
+                      value={values[p.name] || ""}
+                      onChange={(v) => setValues((prev) => ({ ...prev, [p.name]: v }))}
+                    />
+                  ))}
+                </>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-8 text-stone-500">
+                  <span className="text-4xl mb-3">✅</span>
+                  <p className="text-sm font-medium text-white">No variables required</p>
+                  <p className="text-xs mt-1">Click "Apply Template" to insert the note.</p>
+                </div>
+              )}
+              {error && (
+                <div className="flex items-center gap-2 px-3 py-2 bg-red-500/10 border border-red-500/20 rounded-lg text-sm text-red-400">
+                  <svg className="w-4 h-4 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd"/>
+                  </svg>
+                  {error}
+                </div>
+              )}
+            </div>
+
+            {/* Right: mini preview */}
+            <div className="w-72 shrink-0 border-l border-[#1a1a1d] flex flex-col">
+              <div className="px-4 py-3 border-b border-[#1a1a1d]">
+                <p className="text-xs font-medium text-stone-400">Preview</p>
+              </div>
+              <div className="flex-1 overflow-y-auto p-4">
+                <p className="text-[11px] text-stone-200 font-mono leading-relaxed whitespace-pre-wrap line-clamp-[20]">
+                  {renderPreview(selected.body, selected.placeholders, values)}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Footer */}
+        {step === "fill" && (
+          <footer className="flex items-center justify-between px-6 py-4 border-t border-[#222224] shrink-0 bg-[#0d0d0f]">
+            <button
+              onClick={() => setStep("browse")}
+              className="px-4 py-2 text-sm text-stone-400 hover:text-white transition-colors"
+            >
+              ← Back
+            </button>
+            <button
+              onClick={handleApply}
+              disabled={applying}
+              className="flex items-center gap-2 px-5 py-2 text-sm font-medium bg-white text-black rounded-lg
+                hover:bg-stone-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {applying ? (
+                <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+              ) : (
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+              Apply Template
+            </button>
+          </footer>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Sub-components ────────────────────────────────────────────── */
+function CategoryChip({
+  active,
+  onClick,
+  label,
+  icon,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  icon: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap transition-all
+        ${active
+          ? "bg-white text-black"
+          : "bg-white/[0.04] text-stone-400 hover:bg-white/[0.08] border border-white/5"
+        }`}
+    >
+      <span>{icon}</span>
+      {label}
+    </button>
+  );
+}
+
+function PlaceholderField({
+  placeholder,
+  value,
+  onChange,
+}: {
+  placeholder: TemplatePlaceholder;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-xs font-medium text-stone-300">
+        {placeholder.label || placeholder.name}
+        {placeholder.required && <span className="text-red-400 ml-0.5">*</span>}
+      </label>
+      {placeholder.description && (
+        <p className="text-[11px] text-stone-500">{placeholder.description}</p>
+      )}
+      {placeholder.type === "date" ? (
+        <input
+          type="date"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="bg-[#0c0c0e] border border-[#222224] rounded-lg px-3 py-2 text-sm text-stone-200
+            focus:outline-none focus:border-stone-500 transition-colors
+            [color-scheme:dark]"
+        />
+      ) : placeholder.type === "list" ? (
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Comma-separated values…"
+          rows={2}
+          className="bg-[#0c0c0e] border border-[#222224] rounded-lg px-3 py-2 text-sm text-stone-200
+            placeholder-stone-600 focus:outline-none focus:border-stone-500 resize-none transition-colors"
+        />
+      ) : (
+        <input
+          type={placeholder.type === "number" ? "number" : "text"}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder.defaultValue || `Enter ${placeholder.label || placeholder.name}…`}
+          className="bg-[#0c0c0e] border border-[#222224] rounded-lg px-3 py-2 text-sm text-stone-200
+            placeholder-stone-600 focus:outline-none focus:border-stone-500 transition-colors"
+        />
+      )}
+    </div>
+  );
+}
+
+/* ── Helpers ─────────────────────────────────────────────────── */
+function renderPreview(
+  body: string,
+  placeholders: TemplatePlaceholder[],
+  values: Record<string, string>
+): string {
+  let result = body;
+  placeholders?.forEach((p) => {
+    const regex = new RegExp(`\\{\\{\\s*${p.name}\\s*\\}\\}`, "g");
+    result = result.replace(regex, values[p.name] || `[${p.label || p.name}]`);
+  });
+  return result;
+}

--- a/frontend/hooks/useTemplates.ts
+++ b/frontend/hooks/useTemplates.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { apiService } from "@/lib/api";
+import type { Template } from "@/lib/api";
+
+export type TemplateFilters = {
+  category?: string;
+  tags?: string;
+  search?: string;
+  visibility?: string;
+};
+
+export function useTemplates(workspaceId: string) {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTemplates = useCallback(
+    async (filters?: TemplateFilters) => {
+      if (!workspaceId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await apiService.getWorkspaceTemplates(workspaceId, filters);
+        setTemplates(res.templates || []);
+      } catch (err: any) {
+        setError(err.message || "Failed to load templates");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [workspaceId]
+  );
+
+  useEffect(() => {
+    fetchTemplates();
+  }, [fetchTemplates]);
+
+  const createTemplate = useCallback(
+    async (data: Omit<Partial<Template>, "_id" | "usageCount" | "isBuiltIn" | "version">) => {
+      const res = await apiService.createTemplate(workspaceId, data);
+      setTemplates((prev) => [res.template, ...prev]);
+      return res.template;
+    },
+    [workspaceId]
+  );
+
+  const updateTemplate = useCallback(async (id: string, data: Partial<Template>) => {
+    const res = await apiService.updateTemplate(id, data);
+    setTemplates((prev) =>
+      prev.map((t) => (t._id === id ? res.template : t))
+    );
+    return res.template;
+  }, []);
+
+  const deleteTemplate = useCallback(async (id: string) => {
+    await apiService.deleteTemplate(id);
+    setTemplates((prev) => prev.filter((t) => t._id !== id));
+  }, []);
+
+  const copyTemplate = useCallback(
+    async (id: string, visibility?: string) => {
+      const res = await apiService.copyTemplate(id, workspaceId, visibility);
+      setTemplates((prev) => [res.template, ...prev]);
+      return res.template;
+    },
+    [workspaceId]
+  );
+
+  const useTemplate = useCallback(
+    async (id: string, values: Record<string, string>) => {
+      return apiService.useTemplate(id, values);
+    },
+    []
+  );
+
+  const seedBuiltIns = useCallback(async () => {
+    const res = await apiService.seedBuiltInTemplates(workspaceId);
+    await fetchTemplates();
+    return res;
+  }, [workspaceId, fetchTemplates]);
+
+  return {
+    templates,
+    loading,
+    error,
+    refetch: fetchTemplates,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+    copyTemplate,
+    useTemplate,
+    seedBuiltIns,
+  };
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -5,6 +5,10 @@ import {
   NoteVersion,
   User,
   Folder,
+  Template,
+  TemplateCategory,
+  TemplateVisibility,
+  TemplatePlaceholder,
   CreateWorkspaceRequest,
   AddMemberRequest,
   UpdateMemberRoleRequest,
@@ -37,6 +41,10 @@ export type {
   NoteVersion,
   User,
   Folder,
+  Template,
+  TemplateCategory,
+  TemplateVisibility,
+  TemplatePlaceholder,
   CreateWorkspaceRequest,
   AddMemberRequest,
   UpdateMemberRoleRequest,
@@ -126,6 +134,21 @@ class ApiService {
     return response.json();
   }
 
+  /* ---------- Auth ---------- */
+  async login(email: string, password: string): Promise<LoginResponse> {
+    return this.request('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+    });
+  }
+
+  async register(email: string, password: string, name: string): Promise<RegisterResponse> {
+    return this.request('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({ email, password, name }),
+    });
+  }
+
   /* ---------- Workspaces ---------- */
   async getWorkspacesForUser(userId: string): Promise<Workspace[]> {
     return this.request(`/api/workspaces/user/${userId}`);
@@ -193,6 +216,10 @@ class ApiService {
     return this.request(`/api/notes/${id}`);
   }
 
+  async getNoteVersions(noteId: string): Promise<NoteVersion[]> {
+    return this.request(`/api/notes/${noteId}/versions`);
+  }
+
   async createNote(data: CreateNoteRequest): Promise<Note> {
     return this.request("/api/notes", {
       method: "POST",
@@ -214,7 +241,7 @@ class ApiService {
     });
   }
 
-<<<<<<< HEAD
+
   async pinNote(id: string, isPinned: boolean): Promise<Note> {
     return this.request(`/api/notes/${id}/pin`, {
       method: "PATCH",
@@ -261,6 +288,22 @@ class ApiService {
   /* ---------- Tags ---------- */
   async getWorkspaceTags(workspaceId: string): Promise<string[]> {
     return this.request(`/api/notes/workspace/${workspaceId}/tags`);
+  }
+
+  /* ---------- Folders ---------- */
+  async getFolders(workspaceId: string): Promise<Folder[]> {
+    return this.request(`/api/folders/workspace/${workspaceId}`);
+  }
+
+  async createFolder(data: { name: string; workspaceId: string; parentId?: string }): Promise<Folder> {
+    return this.request('/api/folders', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteFolder(folderId: string): Promise<void> {
+    return this.request(`/api/folders/${folderId}`, { method: 'DELETE' });
   }
 
   /* ---------- Invites ---------- */
@@ -347,6 +390,71 @@ class ApiService {
     return this.request(
       `/api/activities/note/${noteId}?limit=${limit}&skip=${skip}`
     );
+  }
+  /* ---------- Templates ---------- */
+  async getBuiltInTemplates(): Promise<{ templates: Template[] }> {
+    return this.request('/api/templates/builtin');
+  }
+
+  async getWorkspaceTemplates(
+    workspaceId: string,
+    params?: { category?: string; tags?: string; search?: string; visibility?: string }
+  ): Promise<{ templates: Template[] }> {
+    const q = new URLSearchParams(params as Record<string, string> || {}).toString();
+    return this.request(`/api/templates/workspace/${workspaceId}${q ? `?${q}` : ''}`);
+  }
+
+  async getTemplate(id: string): Promise<{ template: Template }> {
+    return this.request(`/api/templates/${id}`);
+  }
+
+  async createTemplate(
+    workspaceId: string,
+    data: Omit<Partial<Template>, '_id' | 'usageCount' | 'isBuiltIn' | 'version'>
+  ): Promise<{ template: Template }> {
+    return this.request(`/api/templates/workspace/${workspaceId}`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateTemplate(
+    id: string,
+    data: Partial<Template>
+  ): Promise<{ template: Template }> {
+    return this.request(`/api/templates/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteTemplate(id: string): Promise<{ deleted: boolean; id: string }> {
+    return this.request(`/api/templates/${id}`, { method: 'DELETE' });
+  }
+
+  async copyTemplate(
+    id: string,
+    targetWorkspaceId?: string,
+    visibility?: string
+  ): Promise<{ template: Template }> {
+    return this.request(`/api/templates/${id}/copy`, {
+      method: 'POST',
+      body: JSON.stringify({ targetWorkspaceId, visibility }),
+    });
+  }
+
+  async useTemplate(
+    id: string,
+    values: Record<string, string>
+  ): Promise<{ title: string; body: string }> {
+    return this.request(`/api/templates/${id}/use`, {
+      method: 'POST',
+      body: JSON.stringify({ values }),
+    });
+  }
+
+  async seedBuiltInTemplates(workspaceId: string): Promise<{ seeded: number; total: number }> {
+    return this.request(`/api/templates/seed/${workspaceId}`, { method: 'POST' });
   }
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -209,3 +209,47 @@ export interface AuditLogsResponse {
 export interface ErrorResponse {
   error: string;
 }
+
+/* ─── Templates ─────────────────────────────────────────────────── */
+export type TemplateCategory =
+  | 'meeting'
+  | 'rfc'
+  | 'design'
+  | 'project'
+  | 'bug_report'
+  | 'retrospective'
+  | 'onboarding'
+  | 'research'
+  | 'sprint'
+  | 'general';
+
+export type TemplateVisibility = 'private' | 'workspace' | 'public';
+
+export interface TemplatePlaceholder {
+  name: string;
+  label: string;
+  type: 'text' | 'date' | 'list' | 'number';
+  defaultValue?: string;
+  description?: string;
+  required: boolean;
+}
+
+export interface Template {
+  _id: string;
+  workspaceId: string | null;
+  ownerId: string;
+  title: string;
+  description: string;
+  category: TemplateCategory;
+  tags: string[];
+  body: string;
+  placeholders: TemplatePlaceholder[];
+  visibility: TemplateVisibility;
+  version: number;
+  usageCount: number;
+  previewContent: string;
+  isBuiltIn: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+


### PR DESCRIPTION
Workspace Templates — One-click reusable note structures that help teams kick off meetings, RFCs, bug reports, and retrospectives in seconds instead of staring at blank pages. Includes a curated built-in library and easy custom template management to standardize knowledge capture across your workspace.

<img width="1421" height="721" alt="Screenshot 2026-02-24 at 11 35 02 PM" src="https://github.com/user-attachments/assets/76d1c060-810b-4633-a042-65b45f74b841" />
<img width="990" height="725" alt="Screenshot 2026-02-24 at 11 35 16 PM" src="https://github.com/user-attachments/assets/77f7093d-a695-4df9-9a43-adfec4a4dc6f" />
<img width="909" height="645" alt="Screenshot 2026-02-24 at 11 35 29 PM" src="https://github.com/user-attachments/assets/9c461771-69ef-495f-a633-480cd869fb3f" />
