### PR TITLE
Add confirmation prompt before deleting notes

### DIFF
--- a/frontend/app/notes/notes.tsx
+++ b/frontend/app/notes/notes.tsx
@@ -260,16 +260,19 @@ if (rawPinned) {
 
   /* ---------- Delete with undo ---------- */
   const handleDeleteNote = (note: Note) => {
-    setNotes((prev) => prev.filter((n) => n.id !== note.id));
+  const confirmed = window.confirm("Are you sure you want to delete this note?");
+  if (!confirmed) return;
 
-    // ✅ ADD THIS (keeps pinned storage in sync)
-    setPinnedNoteIds((prev) =>
-      prev.filter((id) => id !== note.id)
-    );
+  setNotes((prev) => prev.filter((n) => n.id !== note.id));
 
-    setRecentlyDeleted(note);
-    setShowUndoToast(true);
-  };
+  // keep pinned storage in sync
+  setPinnedNoteIds((prev) =>
+    prev.filter((id) => id !== note.id)
+  );
+
+  setRecentlyDeleted(note);
+  setShowUndoToast(true);
+};
   /* ---------- Bulk select ---------- */
   const toggleSelectNote = (id: number) => {
     setSelectedNoteIds((prev) =>


### PR DESCRIPTION
## Overview
Currently, deleting a note happens immediately when the delete icon is clicked. This can lead to accidental data loss if a user misclicks.

This PR adds a confirmation step before deleting a note.

## Problem
- Single note deletion occurs instantly
- No confirmation before a destructive action
- Users can accidentally delete important notes

## Solution
- Added a browser confirmation prompt before deleting a note
- Notes are deleted only after user confirmation
- Existing undo functionality remains unchanged
- No backend changes required

## Expected Behavior
- Clicking the delete icon shows a confirmation dialog
- Selecting **Cancel** keeps the note intact
- Selecting **OK** deletes the note and shows the undo option

## Why This Matters
- Prevents accidental data loss
- Improves user trust and safety
- Aligns with standard UX best practices
- High impact with minimal frontend-only changes

### Delete confirmation dialog
![Delete confirmation](<paste-image-link>)
<img width="1589" height="847" alt="Screenshot 2026-02-24 220928" src="https://github.com/user-attachments/assets/3927a067-4be9-492b-9fee-2a4982641cf5" />

### After deletion (undo available)
![Undo toast](<paste-image-link>)
<img width="1385" height="825" alt="Screenshot 2026-02-24 221018" src="https://github.com/user-attachments/assets/0884cff9-756e-4d8e-90a3-cbbdfd5770ae" />
